### PR TITLE
Use minimal transaction format as block codec

### DIFF
--- a/core/beacon/types.go
+++ b/core/beacon/types.go
@@ -133,7 +133,7 @@ func decodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
 	var txs = make([]*types.Transaction, len(enc))
 	for i, encTx := range enc {
 		var tx types.Transaction
-		if err := tx.UnmarshalBinary(encTx); err != nil {
+		if err := tx.UnmarshalMinimal(encTx); err != nil {
 			return nil, fmt.Errorf("invalid transaction %d: %v", i, err)
 		}
 		txs[i] = &tx


### PR DESCRIPTION
A blob transactions has two shapes:
* its networking variant including kzgs and the actual blobs
* block variant including only the blob versioned hashes. This is what that's used to build blocks.

This patch fixes a bug where blob transactions are incorrectly encoded and stored using the networking variant. This ensures that the RLP-encoding of blob transactions used to derive the TxHash uses the block variant. This also ensures that blob transactions are encoded in leveldb using the block variant.