### PR TITLE
fix semantic merge conflict

### DIFF
--- a/core/beacon/types.go
+++ b/core/beacon/types.go
@@ -124,7 +124,7 @@ type ForkchoiceStateV1 struct {
 func encodeTransactions(txs []*types.Transaction) [][]byte {
 	var enc = make([][]byte, len(txs))
 	for i, tx := range txs {
-		enc[i], _ = tx.MarshalBinary()
+		enc[i], _ = tx.MarshalMinimal()
 	}
 	return enc
 }


### PR DESCRIPTION
We decode transactions using `MarshalMinimal` in f15311b8fb46c5790be59a04a53db35d05c51af5. This fixes encoding.