### PR TITLE
Fix point evaluation

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1068,10 +1068,6 @@ func (c *bls12381MapG2) Run(input []byte) ([]byte, error) {
 	return g.EncodePoint(r), nil
 }
 
-var PrecompiledContractsDanksharding = map[common.Address]PrecompiledContract{
-	common.BytesToAddress([]byte{0x14}): &pointEvaluation{},
-}
-
 // pointEvaluation implements the EIP-4844 point evaluation precompile
 // to check if a value is part of a blob at a specific point with a KZG proof.
 type pointEvaluation struct{}


### PR DESCRIPTION
Removes duplicate variable naming that was not uncommitted in the previous PR merge. Fixing the build.