### PR TITLE
Optimize Blob Transaction Validation

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -222,9 +222,13 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
 	case types.BlobTxType:
-		hashes, _, blobs := tx.BlobWrapData()
+		hashes, _, blobs, aggProof := tx.BlobWrapData()
 		if len(hashes) != len(blobs) {
 			return nil, fmt.Errorf("missing blobs data, expected %d blobs", len(hashes))
+		}
+		var z types.KZGProof
+		if aggProof == z {
+			return nil, fmt.Errorf("missing aggregated proof in blobs")
 		}
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())

--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -69,6 +70,52 @@ func (kzg KZGCommitment) ComputeVersionedHash() common.Hash {
 	h := crypto.Keccak256Hash(kzg[:])
 	h[0] = params.BlobCommitmentVersionKZG
 	return h
+}
+
+// Compressed BLS12-381 G1 element
+type KZGProof [48]byte
+
+func (p *KZGProof) Deserialize(dr *codec.DecodingReader) error {
+	if p == nil {
+		return errors.New("nil pubkey")
+	}
+	_, err := dr.Read(p[:])
+	return err
+}
+
+func (p *KZGProof) Serialize(w *codec.EncodingWriter) error {
+	return w.Write(p[:])
+}
+
+func (KZGProof) ByteLength() uint64 {
+	return 48
+}
+
+func (KZGProof) FixedLength() uint64 {
+	return 48
+}
+
+func (p KZGProof) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	var a, b tree.Root
+	copy(a[:], p[0:32])
+	copy(b[:], p[32:48])
+	return hFn(a, b)
+}
+
+func (p KZGProof) MarshalText() ([]byte, error) {
+	return []byte("0x" + hex.EncodeToString(p[:])), nil
+}
+
+func (p KZGProof) String() string {
+	return "0x" + hex.EncodeToString(p[:])
+}
+
+func (p *KZGProof) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("KZGProof", text, p[:])
+}
+
+func (p *KZGProof) Point() (*bls.G1Point, error) {
+	return bls.FromCompressedG1(p[:])
 }
 
 type BLSFieldElement [32]byte
@@ -306,22 +353,76 @@ func (blobs Blobs) ComputeCommitments() (commitments []KZGCommitment, versionedH
 	return commitments, versionedHashes, true
 }
 
+// Return KZG commitments, versioned hashes and the aggregated KZG proof that correspond to these blobs
+func (blobs Blobs) ComputeCommitmentsAndAggregatedProof() (commitments []KZGCommitment, versionedHashes []common.Hash, aggregatedProof KZGProof, err error) {
+	commitments = make([]KZGCommitment, len(blobs))
+	versionedHashes = make([]common.Hash, len(blobs))
+	for i, blob := range blobs {
+		var ok bool
+		commitments[i], ok = blob.ComputeCommitment()
+		if !ok {
+			return nil, nil, KZGProof{}, errors.New("invalid blob for commitment")
+		}
+		versionedHashes[i] = commitments[i].ComputeVersionedHash()
+	}
+
+	var kzgProof KZGProof
+	if len(blobs) != 0 {
+		aggregatePoly, aggregateCommitmentG1, err := computeAggregateKzgCommitment(blobs, commitments)
+		if err != nil {
+			return nil, nil, KZGProof{}, err
+		}
+
+		var aggregateCommitment KZGCommitment
+		copy(aggregateCommitment[:], bls.ToCompressedG1(aggregateCommitmentG1))
+
+		var aggregateBlob Blob
+		for i := range aggregatePoly {
+			aggregateBlob[i] = bls.FrTo32(&aggregatePoly[i])
+		}
+		root := tree.GetHashFn().HashTreeRoot(&aggregateBlob, &aggregateCommitment)
+
+		var x bls.Fr
+		bls.AsFr(&x, binary.BigEndian.Uint64(root[:]))
+		var y bls.Fr
+		kzg.EvaluatePolyInEvaluationForm(&y, aggregatePoly[:], &x)
+
+		aggProofG1, err := kzg.ComputeProof(aggregatePoly, &x)
+		if err != nil {
+			return nil, nil, KZGProof{}, err
+		}
+		copy(kzgProof[:], bls.ToCompressedG1(aggProofG1))
+	}
+
+	return commitments, versionedHashes, kzgProof, nil
+}
+
+type randomChallengeHasher struct {
+	b Blobs
+	c BlobKzgs
+}
+
+func (h *randomChallengeHasher) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	return hFn.HashTreeRoot(&h.b, &h.c)
+}
+
 type BlobTxWrapper struct {
-	Tx       SignedBlobTx
-	BlobKzgs BlobKzgs
-	Blobs    Blobs
+	Tx                 SignedBlobTx
+	BlobKzgs           BlobKzgs
+	Blobs              Blobs
+	KzgAggregatedProof KZGProof
 }
 
 func (txw *BlobTxWrapper) Deserialize(dr *codec.DecodingReader) error {
-	return dr.Container(&txw.Tx, &txw.BlobKzgs, &txw.Blobs)
+	return dr.Container(&txw.Tx, &txw.BlobKzgs, &txw.Blobs, &txw.KzgAggregatedProof)
 }
 
 func (txw *BlobTxWrapper) Serialize(w *codec.EncodingWriter) error {
-	return w.Container(&txw.Tx, &txw.BlobKzgs, &txw.Blobs)
+	return w.Container(&txw.Tx, &txw.BlobKzgs, &txw.Blobs, &txw.KzgAggregatedProof)
 }
 
 func (txw *BlobTxWrapper) ByteLength() uint64 {
-	return codec.ContainerLength(&txw.Tx, &txw.BlobKzgs, &txw.Blobs)
+	return codec.ContainerLength(&txw.Tx, &txw.BlobKzgs, &txw.Blobs, &txw.KzgAggregatedProof)
 }
 
 func (txw *BlobTxWrapper) FixedLength() uint64 {
@@ -329,19 +430,20 @@ func (txw *BlobTxWrapper) FixedLength() uint64 {
 }
 
 func (txw *BlobTxWrapper) HashTreeRoot(hFn tree.HashFn) tree.Root {
-	return hFn.HashTreeRoot(&txw.Tx, &txw.BlobKzgs, &txw.Blobs)
+	return hFn.HashTreeRoot(&txw.Tx, &txw.BlobKzgs, &txw.Blobs, &txw.KzgAggregatedProof)
 }
 
 type BlobTxWrapData struct {
-	BlobKzgs BlobKzgs
-	Blobs    Blobs
+	BlobKzgs           BlobKzgs
+	Blobs              Blobs
+	KzgAggregatedProof KZGProof
 }
 
 func (b *BlobTxWrapData) sizeWrapData() common.StorageSize {
-	return common.StorageSize(4 + 4 + b.BlobKzgs.ByteLength() + b.Blobs.ByteLength())
+	return common.StorageSize(4 + 4 + b.BlobKzgs.ByteLength() + b.Blobs.ByteLength() + b.KzgAggregatedProof.ByteLength())
 }
 
-func (b *BlobTxWrapData) verifyBlobsBatched(inner TxData, joinBatch JoinBlobBatchVerify) error {
+func (b *BlobTxWrapData) verifyVersionedHash(inner TxData) error {
 	blobTx, ok := inner.(*SignedBlobTx)
 	if !ok {
 		return fmt.Errorf("expected signed blob tx, got %T", inner)
@@ -360,24 +462,47 @@ func (b *BlobTxWrapData) verifyBlobsBatched(inner TxData, joinBatch JoinBlobBatc
 			return fmt.Errorf("versioned hash %d supposedly %s but does not match computed %s", i, h, computed)
 		}
 	}
+	return nil
+}
 
-	// Time to verify that the KZG commitments match the included blobs:
-	// first extract crypto material out of our types and pass them to the crypto layer
-	commitments, err := b.BlobKzgs.Parse()
-	if err != nil {
-		return fmt.Errorf("commitments parse error: %v", err)
+// Blob verification using KZG proofs
+func (b *BlobTxWrapData) verifyBlobs(inner TxData) error {
+	if err := b.verifyVersionedHash(inner); err != nil {
+		return err
 	}
-	blobs, err := b.Blobs.Parse()
+
+	aggregatePoly, aggregateCommitmentG1, err := computeAggregateKzgCommitment(b.Blobs, b.BlobKzgs)
 	if err != nil {
-		return fmt.Errorf("blobs parse error: %v", err)
+		return fmt.Errorf("failed to compute aggregate commitment: %v", err)
 	}
-	return joinBatch(commitments, blobs)
+	var aggregateBlob Blob
+	for i := range aggregatePoly {
+		aggregateBlob[i] = bls.FrTo32(&aggregatePoly[i])
+	}
+	var aggregateCommitment KZGCommitment
+	copy(aggregateCommitment[:], bls.ToCompressedG1(aggregateCommitmentG1))
+	root := tree.GetHashFn().HashTreeRoot(&aggregateBlob, &aggregateCommitment)
+
+	var x bls.Fr
+	bls.AsFr(&x, binary.BigEndian.Uint64(root[:]))
+	var y bls.Fr
+	kzg.EvaluatePolyInEvaluationForm(&y, aggregatePoly[:], &x)
+
+	aggregateProofG1, err := b.KzgAggregatedProof.Point()
+	if err != nil {
+		return fmt.Errorf("aggregate proof parse error: %v", err)
+	}
+	if !kzg.VerifyKzgProof(aggregateCommitmentG1, &x, &y, aggregateProofG1) {
+		return errors.New("failed to verify kzg")
+	}
+	return nil
 }
 
 func (b *BlobTxWrapData) copy() TxWrapData {
 	return &BlobTxWrapData{
-		BlobKzgs: b.BlobKzgs.copy(),
-		Blobs:    b.Blobs.copy(),
+		BlobKzgs:           b.BlobKzgs.copy(),
+		Blobs:              b.Blobs.copy(),
+		KzgAggregatedProof: b.KzgAggregatedProof,
 	}
 }
 
@@ -389,6 +514,10 @@ func (b *BlobTxWrapData) blobs() Blobs {
 	return b.Blobs
 }
 
+func (b *BlobTxWrapData) aggregatedProof() KZGProof {
+	return b.KzgAggregatedProof
+}
+
 func (b *BlobTxWrapData) encodeTyped(w io.Writer, txdata TxData) error {
 	if _, err := w.Write([]byte{BlobTxType}); err != nil {
 		return err
@@ -398,9 +527,46 @@ func (b *BlobTxWrapData) encodeTyped(w io.Writer, txdata TxData) error {
 		return fmt.Errorf("expected signed blob tx, got %T", txdata)
 	}
 	wrapped := BlobTxWrapper{
-		Tx:       *blobTx,
-		BlobKzgs: b.BlobKzgs,
-		Blobs:    b.Blobs,
+		Tx:                 *blobTx,
+		BlobKzgs:           b.BlobKzgs,
+		Blobs:              b.Blobs,
+		KzgAggregatedProof: b.KzgAggregatedProof,
 	}
 	return EncodeSSZ(w, &wrapped)
+}
+
+func computePowers(r *bls.Fr, n int) []bls.Fr {
+	var currentPower bls.Fr
+	bls.AsFr(&currentPower, 1)
+	powers := make([]bls.Fr, n)
+	for i := range powers {
+		powers[i] = currentPower
+		bls.MulModFr(&currentPower, &currentPower, r)
+	}
+	return powers
+}
+
+func computeAggregateKzgCommitment(blobs Blobs, commitments []KZGCommitment) ([]bls.Fr, *bls.G1Point, error) {
+	// create challenges
+	hasher := randomChallengeHasher{blobs, commitments}
+	root := hasher.HashTreeRoot(tree.GetHashFn())
+	var r bls.Fr
+	bls.AsFr(&r, binary.BigEndian.Uint64(root[:]))
+	powers := computePowers(&r, len(blobs))
+
+	commitmentsG1 := make([]bls.G1Point, len(commitments))
+	for i := 0; i < len(commitmentsG1); i++ {
+		p, _ := commitments[i].Point()
+		bls.CopyG1(&commitmentsG1[i], p)
+	}
+	aggregateCommitmentG1 := bls.LinCombG1(commitmentsG1, powers)
+	var aggregateCommitment KZGCommitment
+	copy(aggregateCommitment[:], bls.ToCompressedG1(aggregateCommitmentG1))
+
+	polys, err := blobs.Parse()
+	if err != nil {
+		return nil, nil, err
+	}
+	aggregatePoly := kzg.MatrixLinComb(polys, powers)
+	return aggregatePoly, aggregateCommitmentG1, nil
 }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -493,8 +493,9 @@ func TestTransactionCoding(t *testing.T) {
 				},
 			}
 			wrapData = &BlobTxWrapData{
-				BlobKzgs: BlobKzgs{KZGCommitment{0: 0xc0}},
-				Blobs:    Blobs{Blob{}},
+				BlobKzgs:           BlobKzgs{KZGCommitment{0: 0xc0}},
+				Blobs:              Blobs{Blob{}},
+				KzgAggregatedProof: KZGProof{0: 0xd0},
 			}
 		}
 		tx, err := SignNewTx(key, signer, txdata, WithTxWrapData(wrapData))

--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -136,8 +136,9 @@ func benchRLP(b *testing.B, encode bool) {
 						BlobVersionedHashes: VersionedHashesView{common.Hash{0xaa}},
 					},
 				}, WithTxWrapData(&BlobTxWrapData{
-					BlobKzgs: BlobKzgs{KZGCommitment{0xbb}},
-					Blobs:    Blobs{Blob{}},
+					BlobKzgs:           BlobKzgs{KZGCommitment{0xbb}},
+					Blobs:              Blobs{Blob{}},
+					KzgAggregatedProof: KZGProof{0xbc},
 				})),
 		},
 	} {

--- a/crypto/kzg/kzg.go
+++ b/crypto/kzg/kzg.go
@@ -48,7 +48,7 @@ type BlobsBatch struct {
 	aggregateBlob       [params.FieldElementsPerBlob]bls.Fr
 }
 
-func (batch *BlobsBatch) Join(commitments []*bls.G1Point, blobs [][]bls.Fr, aggregateProof *bls.G1Point) error {
+func (batch *BlobsBatch) Join(commitments []*bls.G1Point, blobs [][]bls.Fr) error {
 	batch.Lock()
 	defer batch.Unlock()
 	if len(commitments) != len(blobs) {
@@ -207,42 +207,6 @@ func ComputeProof(eval []bls.Fr, z *bls.Fr) (*bls.G1Point, error) {
 		BigToFr(&quotientPoly[i], &tmp)
 	}
 	return bls.LinCombG1(kzgSetupLagrange, quotientPoly[:]), nil
-}
-
-func polyLongDiv(dividend []bls.Fr, divisor []bls.Fr) []bls.Fr {
-	a := make([]bls.Fr, len(dividend))
-	for i := 0; i < len(a); i++ {
-		bls.CopyFr(&a[i], &dividend[i])
-	}
-	aPos := len(a) - 1
-	bPos := len(divisor) - 1
-	diff := aPos - bPos
-	out := make([]bls.Fr, diff+1)
-	for diff >= 0 {
-		quot := &out[diff]
-		polyFactorDiv(quot, &a[aPos], &divisor[bPos])
-		var tmp, tmp2 bls.Fr
-		for i := bPos; i >= 0; i-- {
-			// In steps: a[diff + i] -= b[i] * quot
-			// tmp =  b[i] * quot
-			bls.MulModFr(&tmp, quot, &divisor[i])
-			// tmp2 = a[diff + i] - tmp
-			bls.SubModFr(&tmp2, &a[diff+i], &tmp)
-			// a[diff + i] = tmp2
-			bls.CopyFr(&a[diff+i], &tmp2)
-		}
-		aPos -= 1
-		diff -= 1
-	}
-	return out
-}
-
-// Helper: invert the divisor, then multiply
-func polyFactorDiv(dst *bls.Fr, a *bls.Fr, b *bls.Fr) {
-	// TODO: use divmod instead.
-	var tmp bls.Fr
-	bls.InvModFr(&tmp, b)
-	bls.MulModFr(dst, &tmp, a)
 }
 
 type JSONTrustedSetup struct {

--- a/crypto/kzg/util.go
+++ b/crypto/kzg/util.go
@@ -1,0 +1,112 @@
+package kzg
+
+import (
+	"math"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
+	gokzg "github.com/protolambda/go-kzg"
+	"github.com/protolambda/go-kzg/bls"
+)
+
+var (
+	BLSModulus *big.Int
+	Domain     []*big.Int
+)
+
+func initDomain() {
+	BLSModulus = new(big.Int)
+	BLSModulus.SetString("0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001", 0)
+
+	// ROOT_OF_UNITY = pow(PRIMITIVE_ROOT, (MODULUS - 1) // WIDTH, MODULUS)
+	primitiveRoot := big.NewInt(7)
+	width := big.NewInt(int64(params.FieldElementsPerBlob))
+	exp := new(big.Int).Div(new(big.Int).Sub(BLSModulus, big.NewInt(-1)), width)
+	rootOfUnity := new(big.Int).Exp(primitiveRoot, exp, BLSModulus)
+	Domain = make([]*big.Int, params.FieldElementsPerBlob)
+	for i := 0; i < params.FieldElementsPerBlob; i++ {
+		Domain[i] = new(big.Int).Exp(rootOfUnity, big.NewInt(int64(i)), BLSModulus)
+	}
+}
+
+func MatrixLinComb(vectors [][]bls.Fr, scalars []bls.Fr) []bls.Fr {
+	r := make([]bls.Fr, len(vectors[0]))
+	for i := 0; i < len(vectors); i++ {
+		var tmp bls.Fr
+		for j := 0; j < len(r); j++ {
+			bls.MulModFr(&tmp, &vectors[i][j], &scalars[i])
+			bls.AddModFr(&r[j], &r[j], &tmp)
+		}
+	}
+	return r
+}
+
+// using the barycentric formula:
+// f(x) = (1 - x**WIDTH) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (x - DOMAIN[i])
+func EvaluatePolyInEvaluationForm(yFr *bls.Fr, poly []bls.Fr, x *bls.Fr) {
+	widthNum := len(poly)
+	if widthNum != params.FieldElementsPerBlob {
+		panic("invalid polynomial len")
+	}
+
+	// TODO(XXX): might wanna use uint256 instead
+	width := big.NewInt(int64(widthNum))
+	var inverseWidth big.Int
+	blsModInv(&inverseWidth, width)
+
+	xB := new(big.Int)
+	frToBig(xB, x)
+	y := new(big.Int)
+	for i := 0; i < widthNum; i++ {
+		var fi big.Int
+		var num big.Int
+		frToBig(&fi, &poly[i])
+		num.Mul(&fi, Domain[i])
+
+		var denom big.Int
+		denom.Sub(xB, Domain[i])
+
+		var div big.Int
+		blsDiv(&div, &num, &denom)
+		y.Add(y, &div)
+	}
+
+	powB := new(big.Int).Exp(xB, width, BLSModulus)
+	powB.Sub(powB, big.NewInt(1))
+
+	y.Mul(y, new(big.Int).Mul(powB, &inverseWidth))
+	y.Mod(y, BLSModulus)
+	bls.SetFr(yFr, y.String())
+}
+
+func frToBig(b *big.Int, val *bls.Fr) {
+	//b.SetBytes((*kilicbls.Fr)(val).RedToBytes())
+	// silly double conversion
+	v := bls.FrTo32(val)
+	for i := 0; i < 16; i++ {
+		v[31-i], v[i] = v[i], v[31-i]
+	}
+	b.SetBytes(v[:])
+}
+
+func blsModInv(out *big.Int, x *big.Int) {
+	if len(x.Bits()) != 0 { // if non-zero
+		out.ModInverse(x, BLSModulus)
+	}
+}
+
+// faster than using big.Int ModDiv
+func blsDiv(out *big.Int, a *big.Int, b *big.Int) {
+	var bInv big.Int
+	blsModInv(&bInv, b)
+	out.Mod(new(big.Int).Mul(a, &bInv), BLSModulus)
+}
+
+func inverseFFT(poly []bls.Fr) ([]bls.Fr, error) {
+	fs := gokzg.NewFFTSettings(uint8(math.Log2(params.FieldElementsPerBlob)))
+	polynomial, err := fs.FFT(poly[:], true)
+	if err != nil {
+		return nil, err
+	}
+	return polynomial, nil
+}

--- a/crypto/kzg/util.go
+++ b/crypto/kzg/util.go
@@ -1,17 +1,15 @@
 package kzg
 
 import (
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/params"
-	gokzg "github.com/protolambda/go-kzg"
 	"github.com/protolambda/go-kzg/bls"
 )
 
 var (
 	BLSModulus *big.Int
-	Domain     []*big.Int
+	Domain     [params.FieldElementsPerBlob]*big.Int
 )
 
 func initDomain() {
@@ -23,7 +21,6 @@ func initDomain() {
 	width := big.NewInt(int64(params.FieldElementsPerBlob))
 	exp := new(big.Int).Div(new(big.Int).Sub(BLSModulus, big.NewInt(-1)), width)
 	rootOfUnity := new(big.Int).Exp(primitiveRoot, exp, BLSModulus)
-	Domain = make([]*big.Int, params.FieldElementsPerBlob)
 	for i := 0; i < params.FieldElementsPerBlob; i++ {
 		Domain[i] = new(big.Int).Exp(rootOfUnity, big.NewInt(int64(i)), BLSModulus)
 	}
@@ -41,23 +38,22 @@ func MatrixLinComb(vectors [][]bls.Fr, scalars []bls.Fr) []bls.Fr {
 	return r
 }
 
-// using the barycentric formula:
+// EvaluatePolyInEvaluationForm evaluates the polynomial using the barycentric formula:
 // f(x) = (1 - x**WIDTH) / WIDTH  *  sum_(i=0)^WIDTH  (f(DOMAIN[i]) * DOMAIN[i]) / (x - DOMAIN[i])
 func EvaluatePolyInEvaluationForm(yFr *bls.Fr, poly []bls.Fr, x *bls.Fr) {
-	widthNum := len(poly)
-	if widthNum != params.FieldElementsPerBlob {
-		panic("invalid polynomial len")
+	if len(poly) != params.FieldElementsPerBlob {
+		panic("invalid polynomial length")
 	}
 
-	// TODO(XXX): might wanna use uint256 instead
-	width := big.NewInt(int64(widthNum))
+	width := big.NewInt(int64(params.FieldElementsPerBlob))
 	var inverseWidth big.Int
 	blsModInv(&inverseWidth, width)
 
 	xB := new(big.Int)
 	frToBig(xB, x)
 	y := new(big.Int)
-	for i := 0; i < widthNum; i++ {
+	for i := 0; i < params.FieldElementsPerBlob; i++ {
+		// To avoid overflow/underflow, convert element into int
 		var fi big.Int
 		var num big.Int
 		frToBig(&fi, &poly[i])
@@ -89,6 +85,17 @@ func frToBig(b *big.Int, val *bls.Fr) {
 	b.SetBytes(v[:])
 }
 
+func BigToFr(out *bls.Fr, in *big.Int) {
+	var b [32]byte
+	inb := in.Bytes()
+	copy(b[32-len(inb):], inb)
+	// again, we have to double convert as go-kzg only accepts little-endian
+	for i := 0; i < 16; i++ {
+		b[31-i], b[i] = b[i], b[31-i]
+	}
+	bls.FrFrom32(out, b)
+}
+
 func blsModInv(out *big.Int, x *big.Int) {
 	if len(x.Bits()) != 0 { // if non-zero
 		out.ModInverse(x, BLSModulus)
@@ -100,13 +107,4 @@ func blsDiv(out *big.Int, a *big.Int, b *big.Int) {
 	var bInv big.Int
 	blsModInv(&bInv, b)
 	out.Mod(new(big.Int).Mul(a, &bInv), BLSModulus)
-}
-
-func inverseFFT(poly []bls.Fr) ([]bls.Fr, error) {
-	fs := gokzg.NewFFTSettings(uint8(math.Log2(params.FieldElementsPerBlob)))
-	polynomial, err := fs.FFT(poly[:], true)
-	if err != nil {
-		return nil, err
-	}
-	return polynomial, nil
 }

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -446,8 +446,9 @@ func testTransactionPropagation(t *testing.T, protocol uint) {
 		},
 	}
 	wrapData := &types.BlobTxWrapData{
-		BlobKzgs: types.BlobKzgs{types.KZGCommitment{0: 0xc0}},
-		Blobs:    types.Blobs{types.Blob{}},
+		BlobKzgs:           types.BlobKzgs{types.KZGCommitment{0: 0xc0}},
+		Blobs:              types.Blobs{types.Blob{}},
+		KzgAggregatedProof: types.KZGProof{0: 0xd0},
 	}
 	blobTx, err := types.SignNewTx(testKey, types.NewDankSigner(common.Big1), txdata, types.WithTxWrapData(wrapData))
 	if err != nil {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -58,7 +58,6 @@ func (h *testEthHandler) RunPeer(*eth.Peer, eth.Handler) error { panic("not used
 func (h *testEthHandler) PeerInfo(enode.ID) interface{}        { panic("not used in tests") }
 
 func (h *testEthHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
-	println("broadcasting")
 	switch packet := packet.(type) {
 	case *eth.NewBlockPacket:
 		h.blockBroadcasts.Send(packet.Block)

--- a/eth/protocols/eth/protocol_test.go
+++ b/eth/protocols/eth/protocol_test.go
@@ -108,7 +108,7 @@ func TestEth66EmptyMessages(t *testing.T) {
 		ReceiptsPacket66{1111, ReceiptsPacket([][]*types.Receipt{})},
 		// Transactions
 		GetPooledTransactionsPacket66{1111, GetPooledTransactionsPacket([]common.Hash{})},
-		PooledTransactionsPacket66{1111, PooledTransactionsPacket([]*types.Transaction{})},
+		PooledTransactionsPacket66{1111, PooledTransactionsPacket([]*types.NetworkTransaction{})},
 		PooledTransactionsRLPPacket66{1111, PooledTransactionsRLPPacket([]rlp.RawValue{})},
 	} {
 		if have, _ := rlp.EncodeToBytes(msg); !bytes.Equal(have, want) {
@@ -127,6 +127,7 @@ func TestEth66Messages(t *testing.T) {
 		blockBody    *BlockBody
 		blockBodyRlp rlp.RawValue
 		txs          []*types.Transaction
+		ntxs         []*types.NetworkTransaction
 		txRlps       []rlp.RawValue
 		hashes       []common.Hash
 		receipts     []*types.Receipt
@@ -154,6 +155,7 @@ func TestEth66Messages(t *testing.T) {
 				t.Fatal(err)
 			}
 			txs = append(txs, tx)
+			ntxs = append(ntxs, types.NewNetworkTransaction(tx))
 			txRlps = append(txRlps, rlpdata)
 		}
 	}
@@ -253,7 +255,7 @@ func TestEth66Messages(t *testing.T) {
 			common.FromHex("f847820457f842a000000000000000000000000000000000000000000000000000000000deadc0dea000000000000000000000000000000000000000000000000000000000feedbeef"),
 		},
 		{
-			PooledTransactionsPacket66{1111, PooledTransactionsPacket(txs)},
+			PooledTransactionsPacket66{1111, PooledTransactionsPacket(ntxs)},
 			common.FromHex("f8d7820457f8d2f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb"),
 		},
 		{

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -273,12 +273,13 @@ func (args *TransactionArgs) toTransaction() *types.Transaction {
 		msg.Value.SetFromBig((*big.Int)(args.Value))
 		msg.Data = args.data()
 		msg.AccessList = types.AccessListView(al)
-		commitments, versionedHashes, ok := types.Blobs(args.Blobs).ComputeCommitments()
+		commitments, versionedHashes, aggregatedProof, err := types.Blobs(args.Blobs).ComputeCommitmentsAndAggregatedProof()
 		// XXX if blobs are invalid we will omit the wrap-data (and an error will pop-up later)
-		if ok {
+		if err == nil {
 			opts = append(opts, types.WithTxWrapData(&types.BlobTxWrapData{
-				BlobKzgs: commitments,
-				Blobs:    args.Blobs,
+				BlobKzgs:           commitments,
+				Blobs:              args.Blobs,
+				KzgAggregatedProof: aggregatedProof,
 			}))
 			msg.BlobVersionedHashes = versionedHashes
 		}

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -159,6 +159,10 @@ func (args *SendTxArgs) ToTransaction() *types.Transaction {
 			wrapData.BlobKzgs = append(wrapData.BlobKzgs, commitment)
 			wrapData.Blobs = append(wrapData.Blobs, bl)
 		}
+		_, _, aggProof, err := types.Blobs(args.Blobs).ComputeCommitmentsAndAggregatedProof()
+		if err == nil {
+			wrapData.KzgAggregatedProof = aggProof
+		}
 		data = &types.SignedBlobTx{Message: msg}
 		return types.NewTx(data, types.WithTxWrapData(&wrapData))
 	case args.MaxFeePerGas != nil:

--- a/tests/kzg_bench_test.go
+++ b/tests/kzg_bench_test.go
@@ -31,7 +31,7 @@ func BenchmarkBlobToKzg(b *testing.B) {
 }
 
 func BenchmarkVerifyBlobs(b *testing.B) {
-	blobs := make([]types.Blob, 2)
+	blobs := make([]types.Blob, params.MaxBlobsPerTx)
 	var commitments []types.KZGCommitment
 	var hashes []common.Hash
 	for i := 0; i < len(blobs); i++ {


### PR DESCRIPTION
Per the spec, we optimize blob transactions using KZG proofs. This requires the addition of an _aggregated proof_ to the blob transaction. The aggregated proof will be included in the blobsBundle so we can optimize blob verification on the CL as well.

# Benchmarks
## Single Transaction Verification (16 blobs):
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/tests
cpu: AMD Ryzen 7 3700X 8-Core Processor

BenchmarkVerifyBlobsWithoutKZGProof-6                 19          62490431 ns/op         2308544 B/op      24993 allocs/op
BenchmarkVerifyBlobs-6                40          27394437 ns/op         2885429 B/op      54122 allocs/op
```

TODO:
- [x] Benchmark the optimization and compare with batch kzg verifcation. While I'm pretty sure this optimization is faster for verifying single transactions, I'd like to confirm if it's still faster than batch verification via linear combinations of blob commitments.
- [ ] Investigate further aggregation for batch transactions. Should be doable given the bilinearity of pairings.
- [x] Compute aggregated KZG proof directly from evaluation form, rather than running inverse fft.