### PR TITLE
Recompute aggregated proof for blobs bundle

### DIFF
--- a/core/beacon/types.go
+++ b/core/beacon/types.go
@@ -226,8 +226,13 @@ func BlockToBlobData(block *types.Block) (*BlobsBundleV1, error) {
 			}
 			blobsBundle.Blobs = append(blobsBundle.Blobs, blobs...)
 			blobsBundle.KZGs = append(blobsBundle.KZGs, kzgs...)
-			blobsBundle.AggregatedProof = aggProof
 		}
 	}
+
+	_, _, aggregatedProof, err := types.Blobs(blobsBundle.Blobs).ComputeCommitmentsAndAggregatedProof()
+	if err != nil {
+		return nil, err
+	}
+	blobsBundle.AggregatedProof = aggregatedProof
 	return blobsBundle, nil
 }


### PR DESCRIPTION
Fixes a bug where blocks with multiple blob transactions would have incorrect aggregated proofs in the blob bundle.