### PR TITLE
Efficient Fiat-Shamir challenges using hashing

### DIFF
--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -18,8 +18,10 @@ package types
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"sync"
 
+	"github.com/protolambda/ztyp/codec"
 	"github.com/protolambda/ztyp/tree"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -125,4 +127,15 @@ func DeriveSha(list DerivableList, hasher TrieHasher) common.Hash {
 		hasher.Update(indexBuf, value)
 	}
 	return hasher.Hash()
+}
+
+// sszHash returns the hash ot the raw serialized ssz-container (i.e. without merkelization)
+func sszHash(c codec.Serializable) ([32]byte, error) {
+	sha := sha256.New()
+	if err := c.Serialize(codec.NewEncodingWriter(sha)); err != nil {
+		return [32]byte{}, err
+	}
+	var sum [32]byte
+	copy(sum[:], sha.Sum(nil))
+	return sum, nil
 }


### PR DESCRIPTION
By avoiding ssz merklelization, we significantly reduce the latency of generating FS
challenges.

```
name                 old time/op    new time/op    delta
VerifyMultiple/8-6     73.9ms ± 0%    40.7ms ± 0%   ~     (p=1.000 n=1+1)
VerifyMultiple/16-6     138ms ± 0%      81ms ± 0%   ~     (p=1.000 n=1+1)

name                 old alloc/op   new alloc/op   delta
VerifyMultiple/8-6     25.2MB ± 0%    22.1MB ± 0%   ~     (p=1.000 n=1+1)
VerifyMultiple/16-6    50.4MB ± 0%    44.1MB ± 0%   ~     (p=1.000 n=1+1)

name                 old allocs/op  new allocs/op  delta
VerifyMultiple/8-6       400k ± 0%      301k ± 0%   ~     (p=1.000 n=1+1)
VerifyMultiple/16-6      800k ± 0%      603k ± 0%   ~     (p=1.000 n=1+1)
```