### PR TITLE
fix potential index out of range bugs in opDataHash

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -206,12 +206,12 @@ func enableSharding(jt *JumpTable) {
 
 // opDataHash implements DATAHASH opcode
 func opDataHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	idx := scope.Stack.pop()
-	if uint64(len(interpreter.evm.TxContext.DataHashes)) < idx.Uint64() {
-		scope.Stack.push(uint256.NewInt(0))
-	} else {
+	idx := scope.Stack.peek()
+	if idx.LtUint64(uint64(len(interpreter.evm.TxContext.DataHashes))) {
 		hash := interpreter.evm.TxContext.DataHashes[idx.Uint64()]
-		scope.Stack.push(new(uint256.Int).SetBytes(hash.Bytes()))
+		idx.SetBytes(hash.Bytes())
+	} else {
+		idx.Clear()
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Array index should be strictly less than the array length, and we should prevent potential uint64 overflow.

Also optimize implementation a bit by using peek() and setting the value directly.

