### PR TITLE
Flexible BlobTx JSON codec

### DIFF
--- a/core/types/types_test.go
+++ b/core/types/types_test.go
@@ -75,14 +75,14 @@ func benchRLP(b *testing.B, encode bool) {
 		{
 			"protodanksharding-header",
 			&Header{
-				Difficulty: big.NewInt(10000000000),
-				Number:     big.NewInt(1000),
-				GasLimit:   8_000_000,
-				GasUsed:    8_000_000,
-				Time:       555,
-				Extra:      make([]byte, 32),
-				BaseFee:    big.NewInt(10000000000),
-				Blobs:      2,
+				Difficulty:  big.NewInt(10000000000),
+				Number:      big.NewInt(1000),
+				GasLimit:    8_000_000,
+				GasUsed:     8_000_000,
+				Time:        555,
+				Extra:       make([]byte, 32),
+				BaseFee:     big.NewInt(10000000000),
+				ExcessBlobs: 2,
 			},
 		},
 		{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1178,7 +1178,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"timestamp":        hexutil.Uint64(head.Time),
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
-		"excessBlobs":      head.ExcessBlobs,
+		"excessBlobs":      hexutil.Uint64(head.ExcessBlobs),
 	}
 
 	if head.BaseFee != nil {
@@ -1305,7 +1305,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.BlobTxType:
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())


### PR DESCRIPTION
This patch allows JSON-encoded Blob Transactions to not contain data. JSON-encoded blob txs returned by JSON-RPC needs this in order to serve transactions from the block body. Otherwise, the marshaling fails as we only persist the minimal representation of transactions in block bodies.
We do not use JSON internally for tx message passing. This only affects JSON-RPC and external APIs.

This also fixes the RPC Block header marshaling.