### PR TITLE
Data gas block limit enforcement + bug fix

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -642,7 +642,14 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	msg := callMsg{call}
 
 	txContext := core.NewEVMTxContext(msg)
-	evmContext := core.NewEVMBlockContext(block.Header(), b.blockchain, nil)
+
+	var excessDataGas *big.Int
+	// Get the last block header
+	ph := b.blockchain.GetHeaderByHash(block.ParentHash())
+	if ph != nil {
+		excessDataGas = ph.ExcessDataGas
+	}
+	evmContext := core.NewEVMBlockContext(block.Header(), excessDataGas, b.blockchain, nil)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmEnv := vm.NewEVM(evmContext, txContext, stateDB, b.config, vm.Config{NoBaseFee: true})

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -346,6 +346,8 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	if chain.Config().IsSharding(header.Number) {
 		if parent := chain.GetHeaderByHash(header.ParentHash); parent != nil {
 			header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
+		} else {
+			header.SetExcessDataGas(new(big.Int))
 		}
 	}
 }

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -579,6 +579,8 @@ func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 	if chain.Config().IsSharding(header.Number) {
 		if parent := chain.GetHeaderByHash(header.ParentHash); parent != nil {
 			header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
+		} else {
+			header.SetExcessDataGas(new(big.Int))
 		}
 	}
 }

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -612,6 +612,8 @@ func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.
 	if chain.Config().IsSharding(header.Number) {
 		if parent := chain.GetHeaderByHash(header.ParentHash); parent != nil {
 			header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
+		} else {
+			header.SetExcessDataGas(new(big.Int))
 		}
 	}
 }

--- a/consensus/misc/eip4844_test.go
+++ b/consensus/misc/eip4844_test.go
@@ -28,7 +28,11 @@ func TestFakeExponential(t *testing.T) {
 		factor, num, denom int64
 		want               int64
 	}{
-		{1, 2, 1, 6}, // approximate 7.389
+		// When num==0 the return value should always equal the value of factor
+		{1, 0, 1, 1},
+		{38493, 0, 1000, 38493},
+		{0, 1234, 2345, 0}, // should be 0
+		{1, 2, 1, 6},       // approximate 7.389
 		{1, 4, 2, 6},
 		{1, 3, 1, 16}, // approximate 20.09
 		{1, 6, 2, 18},

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1656,7 +1656,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 				throwaway, _ := state.New(parent.Root, bc.stateCache, bc.snaps)
 
 				go func(start time.Time, followup *types.Block, throwaway *state.StateDB, interrupt *uint32) {
-					bc.prefetcher.Prefetch(followup, throwaway, bc.vmConfig, &followupInterrupt)
+					bc.prefetcher.Prefetch(followup, parent.ExcessDataGas, throwaway, bc.vmConfig, &followupInterrupt)
 
 					blockPrefetchExecuteTimer.Update(time.Since(start))
 					if atomic.LoadUint32(interrupt) == 1 {
@@ -1668,7 +1668,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 
 		// Process block using the parent state as reference point
 		substart := time.Now()
-		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
+		receipts, logs, usedGas, err := bc.processor.Process(block, parent.ExcessDataGas, statedb, bc.vmConfig)
 		if err != nil {
 			bc.reportBlock(block, receipts, err)
 			atomic.StoreUint32(&followupInterrupt, 1)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -156,11 +156,12 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 			}
 			return err
 		}
-		statedb, err := state.New(blockchain.GetBlockByHash(block.ParentHash()).Root(), blockchain.stateCache, nil)
+		parent := blockchain.GetBlockByHash(block.ParentHash())
+		statedb, err := state.New(parent.Root(), blockchain.stateCache, nil)
 		if err != nil {
 			return err
 		}
-		receipts, _, usedGas, err := blockchain.processor.Process(block, statedb, vm.Config{})
+		receipts, _, usedGas, err := blockchain.processor.Process(block, parent.Header().ExcessDataGas, statedb, vm.Config{})
 		if err != nil {
 			blockchain.reportBlock(block, receipts, err)
 			return err
@@ -3913,7 +3914,6 @@ func TestDataBlobTxs(t *testing.T) {
 
 	blocks, _ := GenerateChain(gspec.Config, genesis, engine, db, 1, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{1})
-		b.SetExcessDataGas(new(big.Int))
 		msg := types.BlobTxMessage{
 			Nonce: 0,
 			Gas:   500000,

--- a/core/gaspool.go
+++ b/core/gaspool.go
@@ -23,32 +23,58 @@ import (
 
 // GasPool tracks the amount of gas available during execution of the transactions
 // in a block. The zero value is a pool with zero gas available.
-type GasPool uint64
+type GasPool struct {
+	gas, dataGas uint64
+}
 
 // AddGas makes gas available for execution.
 func (gp *GasPool) AddGas(amount uint64) *GasPool {
-	if uint64(*gp) > math.MaxUint64-amount {
+	if gp.gas > math.MaxUint64-amount {
 		panic("gas pool pushed above uint64")
 	}
-	*(*uint64)(gp) += amount
+	gp.gas += amount
 	return gp
 }
 
 // SubGas deducts the given amount from the pool if enough gas is
 // available and returns an error otherwise.
 func (gp *GasPool) SubGas(amount uint64) error {
-	if uint64(*gp) < amount {
+	if gp.gas < amount {
 		return ErrGasLimitReached
 	}
-	*(*uint64)(gp) -= amount
+	gp.gas -= amount
 	return nil
 }
 
 // Gas returns the amount of gas remaining in the pool.
 func (gp *GasPool) Gas() uint64 {
-	return uint64(*gp)
+	return gp.gas
+}
+
+// AddDataGas makes data gas available for execution.
+func (gp *GasPool) AddDataGas(amount uint64) *GasPool {
+	if gp.dataGas > math.MaxUint64-amount {
+		panic("data gas pool pushed above uint64")
+	}
+	gp.dataGas += amount
+	return gp
+}
+
+// SubDataGas deducts the given amount from the pool if enough data gas is available and returns an
+// error otherwise.
+func (gp *GasPool) SubDataGas(amount uint64) error {
+	if gp.dataGas < amount {
+		return ErrGasLimitReached
+	}
+	gp.dataGas -= amount
+	return nil
+}
+
+// DataGas returns the amount of data gas remaining in the pool.
+func (gp *GasPool) DataGas() uint64 {
+	return gp.dataGas
 }
 
 func (gp *GasPool) String() string {
-	return fmt.Sprintf("%d", *gp)
+	return fmt.Sprintf("gas: %d, data_gas: %d", gp.gas, gp.dataGas)
 }

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"math/big"
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/consensus"
@@ -47,11 +48,11 @@ func newStatePrefetcher(config *params.ChainConfig, bc *BlockChain, engine conse
 // Prefetch processes the state changes according to the Ethereum rules by running
 // the transaction messages using the statedb, but any changes are discarded. The
 // only goal is to pre-cache transaction signatures and state trie nodes.
-func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, cfg vm.Config, interrupt *uint32) {
+func (p *statePrefetcher) Prefetch(block *types.Block, excessDataGas *big.Int, statedb *state.StateDB, cfg vm.Config, interrupt *uint32) {
 	var (
 		header       = block.Header()
-		gaspool      = new(GasPool).AddGas(block.GasLimit())
-		blockContext = NewEVMBlockContext(header, p.bc, nil)
+		gaspool      = new(GasPool).AddGas(block.GasLimit()).AddDataGas(params.MaxDataGasPerBlock)
+		blockContext = NewEVMBlockContext(header, excessDataGas, p.bc, nil)
 		evm          = vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 		signer       = types.MakeSigner(p.config, header.Number)
 	)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -56,7 +56,7 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // Process returns the receipts and logs accumulated during the process and
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
-func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
+func (p *StateProcessor) Process(block *types.Block, excessDataGas *big.Int, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)
@@ -64,13 +64,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		blockHash   = block.Hash()
 		blockNumber = block.Number()
 		allLogs     []*types.Log
-		gp          = new(GasPool).AddGas(block.GasLimit())
+		gp          = new(GasPool).AddGas(block.GasLimit()).AddDataGas(params.MaxDataGasPerBlock)
 	)
 	// Mutate the block and state according to any hard-fork specs
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
-	blockContext := NewEVMBlockContext(header, p.bc, nil)
+	blockContext := NewEVMBlockContext(header, excessDataGas, p.bc, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
@@ -141,13 +141,13 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, author *com
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
+func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, excessDataGas *big.Int, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
 	if err != nil {
 		return nil, err
 	}
 	// Create a new context to be used in the EVM environment
-	blockContext := NewEVMBlockContext(header, bc, author)
+	blockContext := NewEVMBlockContext(header, excessDataGas, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
 	return applyTransaction(msg, config, author, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
 }

--- a/core/types.go
+++ b/core/types.go
@@ -17,6 +17,8 @@
 package core
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -39,7 +41,7 @@ type Prefetcher interface {
 	// Prefetch processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb, but any changes are discarded. The
 	// only goal is to pre-cache transaction signatures and state trie nodes.
-	Prefetch(block *types.Block, statedb *state.StateDB, cfg vm.Config, interrupt *uint32)
+	Prefetch(block *types.Block, excessDataGas *big.Int, statedb *state.StateDB, cfg vm.Config, interrupt *uint32)
 }
 
 // Processor is an interface for processing blocks using a given initial state.
@@ -47,5 +49,5 @@ type Processor interface {
 	// Process processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb and applying any rewards to both
 	// the processor (coinbase) and any included uncles.
-	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error)
+	Process(block *types.Block, excessDataGas *big.Int, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -414,7 +414,8 @@ func (tx *Transaction) Cost() *big.Int {
 	return total
 }
 
-// DataGas implements get_total_data_gas from EIP-4844
+// DataGas implements get_total_data_gas from EIP-4844. While this returns a big.Int for
+// convenience, it should never exceed math.MaxUint64.
 func (tx *Transaction) DataGas() *big.Int {
 	r := new(big.Int)
 	l := int64(len(tx.DataHashes()))

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -212,13 +212,13 @@ func (b *EthAPIBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
 	return nil
 }
 
-func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
+func (b *EthAPIBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, excessDataGas *big.Int, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 	if vmConfig == nil {
 		vmConfig = b.eth.blockchain.GetVMConfig()
 	}
 	txContext := core.NewEVMTxContext(msg)
-	context := core.NewEVMBlockContext(header, b.eth.BlockChain(), nil)
+	context := core.NewEVMBlockContext(header, excessDataGas, b.eth.BlockChain(), nil)
 	return vm.NewEVM(context, txContext, state, b.eth.blockchain.Config(), *vmConfig), vmError, nil
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -164,7 +164,7 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 	for idx, tx := range block.Transactions() {
 		msg, _ := tx.AsMessage(signer, block.BaseFee())
 		txContext := core.NewEVMTxContext(msg)
-		context := core.NewEVMBlockContext(block.Header(), b.chain, nil)
+		context := core.NewEVMBlockContext(block.Header(), parent.Header().ExcessDataGas, b.chain, nil)
 		if idx == txIndex {
 			return msg, context, statedb, nil
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -953,7 +953,15 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 	if err != nil {
 		return nil, err
 	}
-	evm, vmError, err := b.GetEVM(ctx, msg, state, header, &vm.Config{NoBaseFee: true})
+	var excessDataGas *big.Int
+	ph, err := b.HeaderByHash(ctx, header.ParentHash)
+	if err != nil {
+		return nil, err
+	}
+	if ph != nil {
+		excessDataGas = ph.ExcessDataGas
+	}
+	evm, vmError, err := b.GetEVM(ctx, msg, state, header, excessDataGas, &vm.Config{NoBaseFee: true})
 	if err != nil {
 		return nil, err
 	}
@@ -1446,7 +1454,15 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		// Apply the transaction with the access list tracer
 		tracer := logger.NewAccessListTracer(accessList, args.from(), to, precompiles)
 		config := vm.Config{Tracer: tracer, Debug: true, NoBaseFee: true}
-		vmenv, _, err := b.GetEVM(ctx, msg, statedb, header, &config)
+		var excessDataGas *big.Int
+		ph, err := b.HeaderByHash(ctx, header.ParentHash)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		if ph != nil {
+			excessDataGas = ph.ExcessDataGas
+		}
+		vmenv, _, err := b.GetEVM(ctx, msg, statedb, header, excessDataGas, &config)
 		if err != nil {
 			return nil, 0, nil, err
 		}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -68,7 +68,7 @@ type Backend interface {
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
 	GetTd(ctx context.Context, hash common.Hash) *big.Int
-	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error)
+	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, excessDataGas *big.Int, vmConfig *vm.Config) (*vm.EVM, func() error, error)
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -302,7 +302,7 @@ func (b *backendMock) GetLogs(ctx context.Context, blockHash common.Hash, number
 	return nil, nil
 }
 func (b *backendMock) GetTd(ctx context.Context, hash common.Hash) *big.Int { return nil }
-func (b *backendMock) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
+func (b *backendMock) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, excessDataGas *big.Int, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
 	return nil, nil, nil
 }
 func (b *backendMock) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription { return nil }

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -179,12 +179,12 @@ func (b *LesApiBackend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
 	return nil
 }
 
-func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
+func (b *LesApiBackend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, excessDataGas *big.Int, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
 	if vmConfig == nil {
 		vmConfig = new(vm.Config)
 	}
 	txContext := core.NewEVMTxContext(msg)
-	context := core.NewEVMBlockContext(header, b.eth.blockchain, nil)
+	context := core.NewEVMBlockContext(header, excessDataGas, b.eth.blockchain, nil)
 	return vm.NewEVM(context, txContext, state, b.eth.chainConfig, *vmConfig), state.Error, nil
 }
 

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -137,12 +137,12 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, big.NewInt(params.InitialBaseFee), big.NewInt(params.InitialBaseFee), new(big.Int), new(big.Int), data, nil, nil, true)}
 
-				context := core.NewEVMBlockContext(header, bc, nil)
+				context := core.NewEVMBlockContext(header, nil, bc, nil)
 				txContext := core.NewEVMTxContext(msg)
 				vmenv := vm.NewEVM(context, txContext, statedb, config, vm.Config{NoBaseFee: true})
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
-				gp := new(core.GasPool).AddGas(math.MaxUint64)
+				gp := new(core.GasPool).AddGas(math.MaxUint64).AddDataGas(math.MaxUint64)
 				result, _ := core.ApplyMessage(vmenv, msg, gp)
 				res = append(res, result.Return()...)
 			}
@@ -151,10 +151,10 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			state := light.NewState(ctx, header, lc.Odr())
 			state.SetBalance(bankAddr, math.MaxBig256)
 			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, big.NewInt(params.InitialBaseFee), big.NewInt(params.InitialBaseFee), new(big.Int), new(big.Int), data, nil, nil, true)}
-			context := core.NewEVMBlockContext(header, lc, nil)
+			context := core.NewEVMBlockContext(header, nil, lc, nil)
 			txContext := core.NewEVMTxContext(msg)
 			vmenv := vm.NewEVM(context, txContext, state, config, vm.Config{NoBaseFee: true})
-			gp := new(core.GasPool).AddGas(math.MaxUint64)
+			gp := new(core.GasPool).AddGas(math.MaxUint64).AddDataGas(math.MaxUint64)
 			result, _ := core.ApplyMessage(vmenv, msg, gp)
 			if state.Error() == nil {
 				res = append(res, result.Return()...)

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -57,14 +57,14 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer, block.BaseFee())
 		txContext := core.NewEVMTxContext(msg)
-		context := core.NewEVMBlockContext(block.Header(), leth.blockchain, nil)
+		context := core.NewEVMBlockContext(block.Header(), parent.Header().ExcessDataGas, leth.blockchain, nil)
 		statedb.Prepare(tx.Hash(), idx)
 		if idx == txIndex {
 			return msg, context, statedb, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, leth.blockchain.Config(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()).AddDataGas(tx.DataGas().Uint64())); err != nil {
 			return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -196,9 +196,9 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		st.SetBalance(testBankAddress, math.MaxBig256)
 		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, big.NewInt(params.InitialBaseFee), big.NewInt(params.InitialBaseFee), new(big.Int), new(big.Int), data, nil, nil, true)}
 		txContext := core.NewEVMTxContext(msg)
-		context := core.NewEVMBlockContext(header, chain, nil)
+		context := core.NewEVMBlockContext(header, nil, chain, nil)
 		vmenv := vm.NewEVM(context, txContext, st, config, vm.Config{NoBaseFee: true})
-		gp := new(core.GasPool).AddGas(math.MaxUint64)
+		gp := new(core.GasPool).AddGas(math.MaxUint64).AddDataGas(math.MaxUint64)
 		result, _ := core.ApplyMessage(vmenv, msg, gp)
 		res = append(res, result.Return()...)
 		if st.Error() != nil {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -212,10 +212,13 @@ func (b *testWorkerBackend) newRandomBlobTx(chainID *big.Int, nonce uint64) *typ
 	gasPrice := big.NewInt(10 * params.InitialBaseFee).Uint64()
 	txData := &types.SignedBlobTx{
 		Message: types.BlobTxMessage{
-			ChainID:             view.Uint256View(*uint256.NewInt(chainID.Uint64())),
-			Nonce:               view.Uint64View(nonce),
-			Gas:                 view.Uint64View(testGas),
-			GasFeeCap:           view.Uint256View(*uint256.NewInt(gasPrice)),
+			ChainID:   view.Uint256View(*uint256.NewInt(chainID.Uint64())),
+			Nonce:     view.Uint64View(nonce),
+			Gas:       view.Uint64View(testGas),
+			GasFeeCap: view.Uint256View(*uint256.NewInt(gasPrice)),
+			// fee per data gas needs to be higher than the minimum because this test produces more than one
+			// block and the latter one has non-zero excessDataGas
+			MaxFeePerDataGas:    view.Uint256View(*uint256.NewInt(params.MinDataGasPrice * 2)),
 			GasTipCap:           view.Uint256View(*uint256.NewInt(gasPrice)),
 			Value:               view.Uint256View(*uint256.NewInt(1000)),
 			To:                  types.AddressOptionalSSZ{Address: (*types.AddressSSZ)(&testUserAddress)},

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -229,7 +229,7 @@ func runBenchmark(b *testing.B, t *StateTest) {
 
 			// Prepare the EVM.
 			txContext := core.NewEVMTxContext(msg)
-			context := core.NewEVMBlockContext(block.Header(), nil, &t.json.Env.Coinbase)
+			context := core.NewEVMBlockContext(block.Header(), nil, nil, &t.json.Env.Coinbase)
 			context.GetHash = vmTestBlockHash
 			context.BaseFee = baseFee
 			evm := vm.NewEVM(context, txContext, statedb, config, vmconfig)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -218,7 +218,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 
 	// Prepare the EVM.
 	txContext := core.NewEVMTxContext(msg)
-	context := core.NewEVMBlockContext(block.Header(), nil, &t.json.Env.Coinbase)
+	context := core.NewEVMBlockContext(block.Header(), nil, nil, &t.json.Env.Coinbase)
 	context.GetHash = vmTestBlockHash
 	context.BaseFee = baseFee
 	context.Random = nil
@@ -231,7 +231,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	// Execute the message.
 	snapshot := statedb.Snapshot()
 	gaspool := new(core.GasPool)
-	gaspool.AddGas(block.GasLimit())
+	gaspool.AddGas(block.GasLimit()).AddDataGas(params.MaxDataGasPerBlock)
 	if _, err := core.ApplyMessage(evm, msg, gaspool); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}


### PR DESCRIPTION
- make excess data gas an explicit part of the EVM block context to fix bug from not always using the parent value

- add initial enforcement of block level data gas limit

Still todo: Refund data gas on blob tx rejection