### PR TITLE
add test for nonsharding->sharding transition

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3906,13 +3906,19 @@ func TestDataBlobTxs(t *testing.T) {
 		}
 	)
 
-	gspec.Config.BerlinBlock = common.Big0
-	gspec.Config.LondonBlock = common.Big0
-	gspec.Config.ShardingForkBlock = common.Big0
+	// We test the transition from non-sharding to sharding
+	// Genesis (block 0): AllEthhashProtocolChanges
+	// Block 1          : ""
+	// Block 2          : Sharding
+	gspec.Config.ShardingForkBlock = common.Big2
 	genesis := gspec.MustCommit(db)
 	signer := types.LatestSigner(gspec.Config)
 
-	blocks, _ := GenerateChain(gspec.Config, genesis, engine, db, 1, func(i int, b *BlockGen) {
+	blocks, _ := GenerateChain(gspec.Config, genesis, engine, db, 2, func(i int, b *BlockGen) {
+		if i == 0 {
+			// i==0 is a non-sharding block
+			return
+		}
 		b.SetCoinbase(common.Address{1})
 		msg := types.BlobTxMessage{
 			Nonce: 0,


### PR DESCRIPTION
This PR adds a regression test for the issue where panic would result due to nil excess data gas when there is a blob tx in the first sharding block. I have confirmed this test causes a panic prior to to the fix (https://github.com/mdehoog/go-ethereum/commit/0a53f995e1873b379dd5d5810863921f9626dd05)