### PR TITLE
Suggestions on modifying the crypto API

### DIFF
--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -314,7 +314,7 @@ func (blobs Blobs) copy() Blobs {
 // Return KZG commitments, versioned hashes and the aggregated KZG proof that correspond to these blobs
 func (blobs Blobs) ComputeCommitmentsAndAggregatedProof() (commitments []KZGCommitment, versionedHashes []common.Hash, aggregatedProof KZGProof, err error) {
 
-	_aggregatedProof, _commitments, err := agg_kzg.ComputeAggregateKZGProofAndCommitments(toBlobs(blobs))
+	_aggregatedProof, _commitments, err := agg_kzg.ComputeCommitmentsAndAggregatedProof(toBlobs(blobs))
 	if err != nil {
 		return nil, nil, KZGProof{}, err
 	}

--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -160,6 +160,15 @@ func (blob *Blob) Deserialize(dr *codec.DecodingReader) error {
 	return nil
 }
 
+func (_blob Blob) ComputeCommitment() (KZGCommitment, error) {
+	blob := agg_kzg.Blob(_blob)
+	_comm, err := agg_kzg.ComputeCommitment(&blob)
+	if err != nil {
+		return KZGCommitment{}, err
+	}
+	return KZGCommitment(_comm), nil
+}
+
 func (blob *Blob) Serialize(w *codec.EncodingWriter) error {
 	for i := range blob {
 		if err := w.Write(blob[i][:]); err != nil {
@@ -309,6 +318,16 @@ func (blobs Blobs) copy() Blobs {
 	cpy := make(Blobs, len(blobs))
 	copy(cpy, blobs) // each blob element is an array and gets deep-copied
 	return cpy
+}
+
+func (blobs Blobs) ComputeCommitments() ([]KZGCommitment, error) {
+	_commitments, err := agg_kzg.ComputeCommitments(toBlobs(blobs))
+	if err != nil {
+		return nil, err
+	}
+	commitments := fromComms(_commitments)
+
+	return commitments, nil
 }
 
 // Return KZG commitments, versioned hashes and the aggregated KZG proof that correspond to these blobs

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -18,10 +18,8 @@ package types
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"sync"
 
-	"github.com/protolambda/ztyp/codec"
 	"github.com/protolambda/ztyp/tree"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -127,15 +125,4 @@ func DeriveSha(list DerivableList, hasher TrieHasher) common.Hash {
 		hasher.Update(indexBuf, value)
 	}
 	return hasher.Hash()
-}
-
-// sszHash returns the hash ot the raw serialized ssz-container (i.e. without merkelization)
-func sszHash(c codec.Serializable) ([32]byte, error) {
-	sha := sha256.New()
-	if err := c.Serialize(codec.NewEncodingWriter(sha)); err != nil {
-		return [32]byte{}, err
-	}
-	var sum [32]byte
-	copy(sum[:], sha.Sum(nil))
-	return sum, nil
 }

--- a/crypto/agg_kzg/agg_kzg.go
+++ b/crypto/agg_kzg/agg_kzg.go
@@ -135,6 +135,22 @@ func ComputeCommitments(blobs Blobs) (commitments []KZGCommitment, err error) {
 	return commitments, nil
 }
 
+func ComputeAggregateKZGProofAndCommitments(blobs Blobs) (KZGProof, []KZGCommitment, error) {
+	// Compute the commitments for each blob
+	commitments, err := ComputeCommitments(blobs)
+	if err != nil {
+		return KZGProof{}, nil, err
+	}
+
+	// Compute the KZGProof for all of the blobs
+	aggregatedProof, err := ComputeAggregateKZGProof(blobs, commitments)
+	if err != nil {
+		return KZGProof{}, nil, err
+	}
+
+	return aggregatedProof, commitments, nil
+}
+
 func ComputeAggregateKZGProof(blobs Blobs, commitments []KZGCommitment) (KZGProof, error) {
 	// TODO: here we should return the encoding for the neutral element not 0x00.000
 	var kzgProof KZGProof

--- a/crypto/agg_kzg/agg_kzg.go
+++ b/crypto/agg_kzg/agg_kzg.go
@@ -1,0 +1,205 @@
+package agg_kzg
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto/kzg"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/protolambda/go-kzg/bls"
+)
+
+// Compressed BLS12-381 G1 element
+type KZGCommitment [48]byte
+
+func (p *KZGCommitment) Point() (*bls.G1Point, error) {
+	return bls.FromCompressedG1(p[:])
+}
+
+// Compressed BLS12-381 G1 element
+type KZGProof [48]byte
+
+func (p *KZGProof) Point() (*bls.G1Point, error) {
+	return bls.FromCompressedG1(p[:])
+}
+
+type BLSFieldElement [32]byte
+
+func (p BLSFieldElement) MarshalText() ([]byte, error) {
+	return []byte("0x" + hex.EncodeToString(p[:])), nil
+}
+
+func (p BLSFieldElement) String() string {
+	return "0x" + hex.EncodeToString(p[:])
+}
+
+func (p *BLSFieldElement) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("BLSFieldElement", text, p[:])
+}
+
+// Blob data
+type Blob [params.FieldElementsPerBlob]BLSFieldElement
+
+// Parse blob into Fr elements array
+func (blob *Blob) Parse() (out []bls.Fr, err error) {
+	out = make([]bls.Fr, params.FieldElementsPerBlob)
+	for i, chunk := range blob {
+		ok := bls.FrFrom32(&out[i], chunk)
+		if !ok {
+			return nil, errors.New("internal error commitments")
+		}
+	}
+	return out, nil
+}
+
+type Blobs []Blob
+
+// Extract the crypto material underlying these blobs
+func (blobs Blobs) Parse() ([][]bls.Fr, error) {
+	out := make([][]bls.Fr, len(blobs))
+	for i, b := range blobs {
+		blob, err := b.Parse()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse blob %d: %v", i, err)
+		}
+		out[i] = blob
+	}
+	return out, nil
+}
+
+func computeAggregateKzgCommitment(blobs Blobs, commitments []KZGCommitment) ([]bls.Fr, *bls.G1Point, error) {
+	// create challenges
+	sum, err := sszHash(&BlobsAndCommitments{blobs, commitments})
+	if err != nil {
+		return nil, nil, err
+	}
+	var r bls.Fr
+	hashToFr(&r, sum)
+
+	powers := computePowers(&r, len(blobs))
+
+	commitmentsG1 := make([]bls.G1Point, len(commitments))
+	for i := 0; i < len(commitmentsG1); i++ {
+		p, _ := commitments[i].Point()
+		bls.CopyG1(&commitmentsG1[i], p)
+	}
+	aggregateCommitmentG1 := bls.LinCombG1(commitmentsG1, powers)
+	var aggregateCommitment KZGCommitment
+	copy(aggregateCommitment[:], bls.ToCompressedG1(aggregateCommitmentG1))
+
+	polys, err := blobs.Parse()
+	if err != nil {
+		return nil, nil, err
+	}
+	aggregatePoly := kzg.MatrixLinComb(polys, powers)
+	return aggregatePoly, aggregateCommitmentG1, nil
+}
+
+func computePowers(r *bls.Fr, n int) []bls.Fr {
+	var currentPower bls.Fr
+	bls.AsFr(&currentPower, 1)
+	powers := make([]bls.Fr, n)
+	for i := range powers {
+		powers[i] = currentPower
+		bls.MulModFr(&currentPower, &currentPower, r)
+	}
+	return powers
+}
+
+func ComputeCommitment(blob *Blob) (commitment KZGCommitment, err error) {
+	frs := make([]bls.Fr, len(blob))
+	for i, elem := range blob {
+		if !bls.FrFrom32(&frs[i], elem) {
+			return KZGCommitment{}, errors.New("blob is not canonical, error converting byte representation to a field element")
+		}
+	}
+	// data is presented in eval form
+	commitmentG1 := kzg.BlobToKzg(frs)
+	var out KZGCommitment
+	copy(out[:], bls.ToCompressedG1(commitmentG1))
+	return out, nil
+}
+
+// Return KZG commitments that correspond to these blobs
+func ComputeCommitments(blobs Blobs) (commitments []KZGCommitment, err error) {
+	commitments = make([]KZGCommitment, len(blobs))
+
+	for i, blob := range blobs {
+		commitments[i], err = ComputeCommitment(&blob)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return commitments, nil
+}
+
+func ComputeAggregateKZGProof(blobs Blobs, commitments []KZGCommitment) (KZGProof, error) {
+	// TODO: here we should return the encoding for the neutral element not 0x00.000
+	var kzgProof KZGProof
+	if len(blobs) == 0 {
+		return KZGProof{}, nil
+	}
+	aggregatePoly, aggregateCommitmentG1, err := computeAggregateKzgCommitment(blobs, commitments)
+	if err != nil {
+		return KZGProof{}, err
+	}
+
+	var aggregateCommitment KZGCommitment
+	copy(aggregateCommitment[:], bls.ToCompressedG1(aggregateCommitmentG1))
+
+	var aggregateBlob Blob
+	for i := range aggregatePoly {
+		aggregateBlob[i] = bls.FrTo32(&aggregatePoly[i])
+	}
+	sum, err := sszHash(&PolynomialAndCommitment{aggregateBlob, aggregateCommitment})
+	if err != nil {
+		return KZGProof{}, err
+	}
+	var z bls.Fr
+	hashToFr(&z, sum)
+
+	var y bls.Fr
+	kzg.EvaluatePolyInEvaluationForm(&y, aggregatePoly[:], &z)
+
+	aggProofG1, err := kzg.ComputeProof(aggregatePoly, &z)
+	if err != nil {
+		return KZGProof{}, err
+	}
+	copy(kzgProof[:], bls.ToCompressedG1(aggProofG1))
+
+	return kzgProof, nil
+}
+
+func VerifyAggregateKZGProof(blobs Blobs, blobKzgs []KZGCommitment, aggregatedProof KZGProof) error {
+	aggregatePoly, aggregateCommitmentG1, err := computeAggregateKzgCommitment(blobs, blobKzgs)
+	if err != nil {
+		return fmt.Errorf("failed to compute aggregate commitment: %v", err)
+	}
+	var aggregateBlob Blob
+	for i := range aggregatePoly {
+		aggregateBlob[i] = bls.FrTo32(&aggregatePoly[i])
+	}
+	var aggregateCommitment KZGCommitment
+	copy(aggregateCommitment[:], bls.ToCompressedG1(aggregateCommitmentG1))
+	sum, err := sszHash(&PolynomialAndCommitment{aggregateBlob, aggregateCommitment})
+	if err != nil {
+		return err
+	}
+	var z bls.Fr
+	hashToFr(&z, sum)
+
+	var y bls.Fr
+	kzg.EvaluatePolyInEvaluationForm(&y, aggregatePoly[:], &z)
+
+	aggregateProofG1, err := aggregatedProof.Point()
+	if err != nil {
+		return fmt.Errorf("aggregate proof parse error: %v", err)
+	}
+	if !kzg.VerifyKzgProof(aggregateCommitmentG1, &z, &y, aggregateProofG1) {
+		return errors.New("failed to verify kzg")
+	}
+	return nil
+
+}

--- a/crypto/agg_kzg/agg_kzg.go
+++ b/crypto/agg_kzg/agg_kzg.go
@@ -135,7 +135,7 @@ func ComputeCommitments(blobs Blobs) (commitments []KZGCommitment, err error) {
 	return commitments, nil
 }
 
-func ComputeAggregateKZGProofAndCommitments(blobs Blobs) (KZGProof, []KZGCommitment, error) {
+func ComputeCommitmentsAndAggregatedProof(blobs Blobs) (KZGProof, []KZGCommitment, error) {
 	// Compute the commitments for each blob
 	commitments, err := ComputeCommitments(blobs)
 	if err != nil {

--- a/crypto/agg_kzg/ssz_structures.go
+++ b/crypto/agg_kzg/ssz_structures.go
@@ -1,0 +1,266 @@
+package agg_kzg
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto/kzg"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/protolambda/go-kzg/bls"
+	"github.com/protolambda/ztyp/codec"
+	"github.com/protolambda/ztyp/tree"
+)
+
+// This file will be rendered obsolete with the new crypto API
+
+func hashToFr(out *bls.Fr, h [32]byte) {
+	// re-interpret as little-endian
+	var b [32]byte = h
+	for i := 0; i < 16; i++ {
+		b[31-i], b[i] = b[i], b[31-i]
+	}
+	zB := new(big.Int).Mod(new(big.Int).SetBytes(b[:]), kzg.BLSModulus)
+	_ = kzg.BigToFr(out, zB)
+}
+
+type blobKzgs []KZGCommitment
+
+type BlobsAndCommitments struct {
+	Blobs    Blobs
+	blobKzgs blobKzgs
+}
+
+func (b *BlobsAndCommitments) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	return hFn.HashTreeRoot(&b.Blobs, &b.blobKzgs)
+}
+
+func (b *BlobsAndCommitments) Serialize(w *codec.EncodingWriter) error {
+	return w.Container(&b.Blobs, &b.blobKzgs)
+}
+
+func (b *BlobsAndCommitments) ByteLength() uint64 {
+	return codec.ContainerLength(&b.Blobs, &b.blobKzgs)
+}
+
+func (b *BlobsAndCommitments) FixedLength() uint64 {
+	return 0
+}
+
+type PolynomialAndCommitment struct {
+	b Blob
+	c KZGCommitment
+}
+
+func (p *PolynomialAndCommitment) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	return hFn.HashTreeRoot(&p.b, &p.c)
+}
+
+func (p *PolynomialAndCommitment) Serialize(w *codec.EncodingWriter) error {
+	return w.Container(&p.b, &p.c)
+}
+
+func (p *PolynomialAndCommitment) ByteLength() uint64 {
+	return codec.ContainerLength(&p.b, &p.c)
+}
+
+func (p *PolynomialAndCommitment) FixedLength() uint64 {
+	return 0
+}
+
+// sszHash returns the hash ot the raw serialized ssz-container (i.e. without merkelization)
+func sszHash(c codec.Serializable) ([32]byte, error) {
+	sha := sha256.New()
+	if err := c.Serialize(codec.NewEncodingWriter(sha)); err != nil {
+		return [32]byte{}, err
+	}
+	var sum [32]byte
+	copy(sum[:], sha.Sum(nil))
+	return sum, nil
+}
+
+// These methods are needed because we want the PolynomialAndCommitment and BlobsAndCommitment methods to work
+
+func (a *Blobs) Deserialize(dr *codec.DecodingReader) error {
+	return dr.List(func() codec.Deserializable {
+		i := len(*a)
+		*a = append(*a, Blob{})
+		return &(*a)[i]
+	}, params.FieldElementsPerBlob*32, params.FieldElementsPerBlob)
+}
+
+func (a Blobs) Serialize(w *codec.EncodingWriter) error {
+	return w.List(func(i uint64) codec.Serializable {
+		return &a[i]
+	}, params.FieldElementsPerBlob*32, uint64(len(a)))
+}
+
+func (a Blobs) ByteLength() (out uint64) {
+	return uint64(len(a)) * params.FieldElementsPerBlob * 32
+}
+
+func (a *Blobs) FixedLength() uint64 {
+	return 0 // it's a list, no fixed length
+}
+
+func (li Blobs) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	length := uint64(len(li))
+	return hFn.ComplexListHTR(func(i uint64) tree.HTR {
+		if i < length {
+			return &li[i]
+		}
+		return nil
+	}, length, params.MaxBlobsPerBlock)
+}
+
+func (blob *Blob) Deserialize(dr *codec.DecodingReader) error {
+	if blob == nil {
+		return errors.New("cannot decode ssz into nil Blob")
+	}
+	for i := uint64(0); i < params.FieldElementsPerBlob; i++ {
+		// TODO: do we want to check if each field element is within range?
+		if _, err := dr.Read(blob[i][:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (blob *Blob) Serialize(w *codec.EncodingWriter) error {
+	for i := range blob {
+		if err := w.Write(blob[i][:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (blob *Blob) ByteLength() (out uint64) {
+	return params.FieldElementsPerBlob * 32
+}
+
+func (blob *Blob) FixedLength() uint64 {
+	return params.FieldElementsPerBlob * 32
+}
+
+func (blob *Blob) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	return hFn.ComplexVectorHTR(func(i uint64) tree.HTR {
+		return (*tree.Root)(&blob[i])
+	}, params.FieldElementsPerBlob)
+}
+
+func (blob *Blob) MarshalText() ([]byte, error) {
+	out := make([]byte, 2+params.FieldElementsPerBlob*32*2)
+	copy(out[:2], "0x")
+	j := 2
+	for _, elem := range blob {
+		hex.Encode(out[j:j+64], elem[:])
+		j += 64
+	}
+	return out, nil
+}
+
+func (blob *Blob) String() string {
+	v, err := blob.MarshalText()
+	if err != nil {
+		return "<invalid-blob>"
+	}
+	return string(v)
+}
+
+func (blob *Blob) UnmarshalText(text []byte) error {
+	if blob == nil {
+		return errors.New("cannot decode text into nil Blob")
+	}
+	l := 2 + params.FieldElementsPerBlob*32*2
+	if len(text) != l {
+		return fmt.Errorf("expected %d characters but got %d", l, len(text))
+	}
+	if !(text[0] == '0' && text[1] == 'x') {
+		return fmt.Errorf("expected '0x' prefix in Blob string")
+	}
+	j := 0
+	for i := 2; i < l; i += 64 {
+		if _, err := hex.Decode(blob[j][:], text[i:i+64]); err != nil {
+			return fmt.Errorf("blob item %d is not formatted correctly: %v", j, err)
+		}
+		j += 1
+	}
+	return nil
+}
+
+func (p *KZGCommitment) Deserialize(dr *codec.DecodingReader) error {
+	if p == nil {
+		return errors.New("nil pubkey")
+	}
+	_, err := dr.Read(p[:])
+	return err
+}
+
+func (p *KZGCommitment) Serialize(w *codec.EncodingWriter) error {
+	return w.Write(p[:])
+}
+
+func (KZGCommitment) ByteLength() uint64 {
+	return 48
+}
+
+func (KZGCommitment) FixedLength() uint64 {
+	return 48
+}
+
+func (p KZGCommitment) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	var a, b tree.Root
+	copy(a[:], p[0:32])
+	copy(b[:], p[32:48])
+	return hFn(a, b)
+}
+
+func (p KZGCommitment) MarshalText() ([]byte, error) {
+	return []byte("0x" + hex.EncodeToString(p[:])), nil
+}
+
+func (p KZGCommitment) String() string {
+	return "0x" + hex.EncodeToString(p[:])
+}
+
+func (p *KZGCommitment) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("KZGCommitment", text, p[:])
+}
+
+func (li *blobKzgs) Deserialize(dr *codec.DecodingReader) error {
+	return dr.List(func() codec.Deserializable {
+		i := len(*li)
+		*li = append(*li, KZGCommitment{})
+		return &(*li)[i]
+	}, 48, params.MaxBlobsPerBlock)
+}
+
+func (li blobKzgs) Serialize(w *codec.EncodingWriter) error {
+	return w.List(func(i uint64) codec.Serializable {
+		return &li[i]
+	}, 48, uint64(len(li)))
+}
+
+func (li blobKzgs) ByteLength() uint64 {
+	return uint64(len(li)) * 48
+}
+
+func (li *blobKzgs) FixedLength() uint64 {
+	return 0
+}
+
+func (li blobKzgs) HashTreeRoot(hFn tree.HashFn) tree.Root {
+	return hFn.ComplexListHTR(func(i uint64) tree.HTR {
+		return &li[i]
+	}, uint64(len(li)), params.MaxBlobsPerBlock)
+}
+
+func (li blobKzgs) copy() blobKzgs {
+	cpy := make(blobKzgs, len(li))
+	copy(cpy, li)
+	return cpy
+}

--- a/crypto/kzg/kzg.go
+++ b/crypto/kzg/kzg.go
@@ -24,6 +24,8 @@ var KzgSetupG1 []bls.G1Point
 
 // Convert polynomial in evaluation form to KZG commitment
 func BlobToKzg(eval []bls.Fr) *bls.G1Point {
+	// TODO: Note that this method panics when the
+	// TODO number of points does not match the number of scalars
 	return bls.LinCombG1(kzgSetupLagrange, eval)
 }
 

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -149,8 +149,8 @@ func (args *SendTxArgs) ToTransaction() *types.Transaction {
 		msg.AccessList = types.AccessListView(al)
 		wrapData := types.BlobTxWrapData{}
 		for _, bl := range args.Blobs {
-			commitment, ok := bl.ComputeCommitment()
-			if !ok {
+			commitment, err := bl.ComputeCommitment()
+			if err != nil {
 				// invalid BLS blob data (e.g. element not within field element range)
 				continue // can't error, so ignore the malformed blob
 			}


### PR DESCRIPTION
With the new crypto API in 3038, there is now a clear delineation between the cryptography code and the client code. 

However, the client code will also need to implement interface methods on types defined in cryptography. This PR suggests a way to do this without modifying the existing behaviour of the code. 