### PR TITLE
Migrate remaining EIP-4844 consensus api functions to kzg_new

### DIFF
--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -296,21 +296,6 @@ func (blobs Blobs) copy() Blobs {
 	return cpy
 }
 
-// Return KZG commitments and versioned hashes that correspond to these blobs
-func (blobs Blobs) ComputeCommitments() ([]KZGCommitment, []common.Hash, bool) {
-	commitments := make([]KZGCommitment, len(blobs))
-	versionedHashes := make([]common.Hash, len(blobs))
-	for i, blob := range blobs {
-		frs, ok := blob.ToKZGBlob()
-		if !ok {
-			return nil, nil, false
-		}
-		commitments[i] = KZGCommitment(kzg.BlobToKZGCommitment(frs))
-		versionedHashes[i] = common.Hash(kzg.KZGToVersionedHash(kzg.KZGCommitment(commitments[i])))
-	}
-	return commitments, versionedHashes, true
-}
-
 // Return KZG commitments, versioned hashes and the aggregated KZG proof that correspond to these blobs
 func (blobs Blobs) ComputeCommitmentsAndAggregatedProof() (commitments []KZGCommitment, versionedHashes []common.Hash, aggregatedProof KZGProof, err error) {
 	commitments = make([]KZGCommitment, len(blobs))

--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -296,6 +296,21 @@ func (blobs Blobs) copy() Blobs {
 	return cpy
 }
 
+// Return KZG commitments and versioned hashes that correspond to these blobs
+func (blobs Blobs) ComputeCommitments() ([]KZGCommitment, []common.Hash, bool) {
+	commitments := make([]KZGCommitment, len(blobs))
+	versionedHashes := make([]common.Hash, len(blobs))
+	for i, blob := range blobs {
+		frs, ok := blob.ToKZGBlob()
+		if !ok {
+			return nil, nil, false
+		}
+		commitments[i] = KZGCommitment(kzg.BlobToKZGCommitment(frs))
+		versionedHashes[i] = common.Hash(kzg.KZGToVersionedHash(kzg.KZGCommitment(commitments[i])))
+	}
+	return commitments, versionedHashes, true
+}
+
 // Return KZG commitments, versioned hashes and the aggregated KZG proof that correspond to these blobs
 func (blobs Blobs) ComputeCommitmentsAndAggregatedProof() (commitments []KZGCommitment, versionedHashes []common.Hash, aggregatedProof KZGProof, err error) {
 	commitments = make([]KZGCommitment, len(blobs))

--- a/crypto/kzg/util.go
+++ b/crypto/kzg/util.go
@@ -32,11 +32,6 @@ func initDomain() {
 	}
 }
 
-// EvaluatePolyInEvaluationForm evaluates the polynomial using the barycentric formula
-func EvaluatePolyInEvaluationForm(yFr *bls.Fr, poly []bls.Fr, x *bls.Fr) {
-	bls.EvaluatePolyInEvaluationForm(yFr, poly, x, DomainFr, 0)
-}
-
 func frToBig(b *big.Int, val *bls.Fr) {
 	//b.SetBytes((*kilicbls.Fr)(val).RedToBytes())
 	// silly double conversion


### PR DESCRIPTION
... and also update the implementations according to the latest 4844 spec.

One remaining bug is the fact that we currently have the EL computing the aggregated proof, whereas this should be done in the CL.  I will fix this in a later PR, once I've gotten further with ensuring these changes make it into our prysm fork.

