### PR TITLE
set min data gas price to 1 per latest spec, remove unused ssz hash funcs

### DIFF
--- a/core/types/data_blob_tx.go
+++ b/core/types/data_blob_tx.go
@@ -36,10 +36,6 @@ func (*ECDSASignature) FixedLength() uint64 {
 	return 1 + 32 + 32
 }
 
-func (sig *ECDSASignature) HashTreeRoot(hFn tree.HashFn) tree.Root {
-	return hFn.HashTreeRoot(&sig.V, &sig.R, &sig.S)
-}
-
 type AddressSSZ common.Address
 
 func (addr *AddressSSZ) Deserialize(dr *codec.DecodingReader) error {
@@ -346,6 +342,14 @@ func (tx *BlobTxMessage) FixedLength() uint64 {
 	return 0
 }
 
+func (stx *SignedBlobTx) ByteLength() uint64 {
+	return codec.ContainerLength(&stx.Message, &stx.Signature)
+}
+
+func (stx *SignedBlobTx) FixedLength() uint64 {
+	return 0
+}
+
 func (tx *BlobTxMessage) HashTreeRoot(hFn tree.HashFn) tree.Root {
 	return hFn.HashTreeRoot(&tx.ChainID, &tx.Nonce, &tx.GasTipCap, &tx.GasFeeCap, &tx.Gas, &tx.To, &tx.Value, &tx.Data, &tx.AccessList, &tx.MaxFeePerDataGas, &tx.BlobVersionedHashes)
 }
@@ -389,18 +393,6 @@ func (stx *SignedBlobTx) Deserialize(dr *codec.DecodingReader) error {
 
 func (stx *SignedBlobTx) Serialize(w *codec.EncodingWriter) error {
 	return w.Container(&stx.Message, &stx.Signature)
-}
-
-func (stx *SignedBlobTx) ByteLength() uint64 {
-	return codec.ContainerLength(&stx.Message, &stx.Signature)
-}
-
-func (stx *SignedBlobTx) FixedLength() uint64 {
-	return 0
-}
-
-func (stx *SignedBlobTx) HashTreeRoot(hFn tree.HashFn) tree.Root {
-	return hFn.HashTreeRoot(&stx.Message, &stx.Signature)
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -163,7 +163,7 @@ const (
 	MaxDataGasPerBlock         = 1 << 21
 	DataGasPerBlob             = 1 << 17
 	TargetDataGasPerBlock      = 1 << 20
-	MinDataGasPrice            = 10e8
+	MinDataGasPrice            = 1
 	DataGasPriceUpdateFraction = 8902606
 	MaxBlobsPerBlock           = MaxDataGasPerBlock / DataGasPerBlob
 


### PR DESCRIPTION
1) implement decision from last 4844 dev sync to just leave min data gas at 1

2) remove some ssz hash functions from blob wrap data that are not needed (only blobTxMessage gets ssz-hashed)

