### PR TITLE
revert changes to IntrinsicGas from earlier EIP-4844 work

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -138,16 +138,9 @@ func Transaction(ctx *cli.Context) error {
 		} else {
 			r.Address = sender
 		}
-		// Check intrinsic gas assuming no excess data gas
-		// NOTE: We set excess_data_gas prestate to zero. So this may not accurately compute the
-		// intrinsic gas unless the tool is updated to take in an excess_data_gas parameter.
-
-		rules := core.IntrinsicGasChainRules{
-			Homestead: chainConfig.IsHomestead(new(big.Int)),
-			EIP2028:   chainConfig.IsIstanbul(new(big.Int)),
-			EIP4844:   chainConfig.IsSharding(new(big.Int)),
-		}
-		if gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, rules); err != nil {
+		// Check intrinsic gas
+		if gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil,
+			chainConfig.IsHomestead(new(big.Int)), chainConfig.IsIstanbul(new(big.Int))); err != nil {
 			r.Error = err
 			results = append(results, r)
 			continue

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -83,12 +83,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		rules := IntrinsicGasChainRules{
-			Homestead: false,
-			EIP2028:   false,
-			EIP4844:   false,
-		}
-		gas, _ := IntrinsicGas(data, nil, false, rules)
+		gas, _ := IntrinsicGas(data, nil, false, false, false)
 		signer := types.MakeSigner(gen.config, big.NewInt(int64(i)))
 		gasPrice := big.NewInt(0)
 		if gen.header.BaseFee != nil {

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -657,13 +657,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return core.ErrInsufficientFunds
 	}
-	// Ensure the transaction has more gas than the basic tx fee.
-	rules := core.IntrinsicGasChainRules{
-		Homestead: true,
-		EIP2028:   pool.istanbul,
-		EIP4844:   pool.eip4844,
-	}
-	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, rules)
+	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul)
 	if err != nil {
 		return err
 	}

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -70,7 +70,6 @@ type TxPool struct {
 
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
 	eip2718  bool // Fork indicator whether we are in the eip2718 stage.
-	eip4844  bool // Fork indicator whether we are in the eip4844 stage.
 }
 
 // TxRelayBackend provides an interface to the mechanism that forwards transactions to the
@@ -318,7 +317,6 @@ func (pool *TxPool) setNewHead(head *types.Header) {
 	next := new(big.Int).Add(head.Number, big.NewInt(1))
 	pool.istanbul = pool.config.IsIstanbul(next)
 	pool.eip2718 = pool.config.IsBerlin(next)
-	pool.eip4844 = pool.config.IsSharding(next)
 }
 
 // Stop stops the light transaction pool
@@ -386,12 +384,7 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	}
 
 	// Should supply enough intrinsic gas
-	rules := core.IntrinsicGasChainRules{
-		Homestead: true,
-		EIP2028:   pool.istanbul,
-		EIP4844:   pool.eip4844,
-	}
-	gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, rules)
+	gas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, pool.istanbul)
 	if err != nil {
 		return err
 	}

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -56,12 +56,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
-		rules := core.IntrinsicGasChainRules{
-			Homestead: isHomestead,
-			EIP2028:   isIstanbul,
-			EIP4844:   isSharding,
-		}
-		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, rules)
+		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, isHomestead, isIstanbul)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Earlier versions of EIP-4844 required changes to IntrinsicGas which are no longer needed. This PR reverts some of the remaining changes we had made to the IntrinsicGas & related code due to that older spec.
