### PR TITLE
Withdrawal Fixes

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -479,7 +479,10 @@ func (g *Genesis) ToBlock() *types.Block {
 				head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 			}
 		}
-		if g.Config.IsSharding(0) {
+		if g.Config.IsShanghai(g.Timestamp) {
+			head.WithdrawalsHash = &types.EmptyRootHash
+		}
+		if g.Config.IsSharding(g.Timestamp) {
 			head.SetExcessDataGas(g.ExcessDataGas)
 		}
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -182,9 +182,12 @@ func (h *Header) SanityCheck() error {
 }
 
 // EmptyBody returns true if there is no additional 'body' to complete the header
-// that is: no transactions and no uncles.
+// that is: no transactions, no uncles and no withdrawals.
 func (h *Header) EmptyBody() bool {
-	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash
+	if h.WithdrawalsHash == nil {
+		return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash
+	}
+	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash && *h.WithdrawalsHash == EmptyRootHash
 }
 
 // EmptyReceipts returns true if there are no receipts for this header/block.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1247,6 +1247,8 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 			}
 		}
 		fields["transactions"] = transactions
+		// inclTx also expands withdrawals
+		fields["withdrawals"] = block.Withdrawals()
 	}
 	uncles := block.Uncles()
 	uncleHashes := make([]common.Hash, len(uncles))

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1248,6 +1248,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 		}
 		fields["transactions"] = transactions
 		// inclTx also expands withdrawals
+		// TODO @MariusVanDerWijden: add a second flag similar to inclTx to enable withdrawals
 		fields["withdrawals"] = block.Withdrawals()
 	}
 	uncles := block.Uncles()


### PR DESCRIPTION
The withdrawals object is included in the block JSON-RPC  response per https://github.com/ethereum/execution-apis/pull/334. This fixes interop with lighthouse.