### PR TITLE
minor/cosmetic improvements to data gas handling in state transition

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -88,7 +88,7 @@ var (
 
 	// ErrMaxFeePerDataGas is returned if the transaction specified a
 	// max_fee_per_data_gas that is below the current data gas price.
-	ErrMaxFeePerDataGas = errors.New("max data fee per gas too low")
+	ErrMaxFeePerDataGas = errors.New("max fee per data gas too low")
 
 	// ErrTipVeryHigh is a sanity error to avoid extremely big numbers specified
 	// in the tip field.
@@ -104,4 +104,8 @@ var (
 
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")
+
+	// ErrInternalFailure is returned when an unexpected internal error condition
+	// prevents execution.
+	ErrInternalFailure = errors.New("internal failure")
 )


### PR DESCRIPTION
- fix error that wasn't wrapping one of the underlying execution errors as expected by the error handler

- change dataGasUsed to return type uint64 which is more convenient than big int

- remove confusing comment I had added earlier around gas refunds
