### PR TITLE
cmd/evm: add excess data gas to t8n environment

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -140,6 +140,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	)
 	// TODO(4844): Add DataGasLimit to prestate
 	gaspool.AddGas(pre.Env.GasLimit)
+	gaspool.AddDataGas(params.MaxDataGasPerBlock)
 	vmContext := vm.BlockContext{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -67,37 +67,41 @@ type ommer struct {
 
 //go:generate go run github.com/fjl/gencodec -type stEnv -field-override stEnvMarshaling -out gen_stenv.go
 type stEnv struct {
-	Coinbase         common.Address                      `json:"currentCoinbase"   gencodec:"required"`
-	Difficulty       *big.Int                            `json:"currentDifficulty"`
-	Random           *big.Int                            `json:"currentRandom"`
-	ParentDifficulty *big.Int                            `json:"parentDifficulty"`
-	ParentBaseFee    *big.Int                            `json:"parentBaseFee,omitempty"`
-	ParentGasUsed    uint64                              `json:"parentGasUsed,omitempty"`
-	ParentGasLimit   uint64                              `json:"parentGasLimit,omitempty"`
-	GasLimit         uint64                              `json:"currentGasLimit"   gencodec:"required"`
-	Number           uint64                              `json:"currentNumber"     gencodec:"required"`
-	Timestamp        uint64                              `json:"currentTimestamp"  gencodec:"required"`
-	ParentTimestamp  uint64                              `json:"parentTimestamp,omitempty"`
-	BlockHashes      map[math.HexOrDecimal64]common.Hash `json:"blockHashes,omitempty"`
-	Ommers           []ommer                             `json:"ommers,omitempty"`
-	Withdrawals      []*types.Withdrawal                 `json:"withdrawals,omitempty"`
-	BaseFee          *big.Int                            `json:"currentBaseFee,omitempty"`
-	ParentUncleHash  common.Hash                         `json:"parentUncleHash"`
+	Coinbase            common.Address                      `json:"currentCoinbase"   gencodec:"required"`
+	Difficulty          *big.Int                            `json:"currentDifficulty"`
+	Random              *big.Int                            `json:"currentRandom"`
+	ParentDifficulty    *big.Int                            `json:"parentDifficulty"`
+	ParentBaseFee       *big.Int                            `json:"parentBaseFee,omitempty"`
+	ParentGasUsed       uint64                              `json:"parentGasUsed,omitempty"`
+	ParentGasLimit      uint64                              `json:"parentGasLimit,omitempty"`
+	ParentExcessDataGas *big.Int                            `json:"parentExcessDataGas,omitempty"`
+	GasLimit            uint64                              `json:"currentGasLimit"   gencodec:"required"`
+	Number              uint64                              `json:"currentNumber"     gencodec:"required"`
+	Timestamp           uint64                              `json:"currentTimestamp"  gencodec:"required"`
+	ParentTimestamp     uint64                              `json:"parentTimestamp,omitempty"`
+	BlockHashes         map[math.HexOrDecimal64]common.Hash `json:"blockHashes,omitempty"`
+	Ommers              []ommer                             `json:"ommers,omitempty"`
+	Withdrawals         []*types.Withdrawal                 `json:"withdrawals,omitempty"`
+	BaseFee             *big.Int                            `json:"currentBaseFee,omitempty"`
+	ExcessDataGas       *big.Int                            `json:"currentExcessDataGas,omitempty"`
+	ParentUncleHash     common.Hash                         `json:"parentUncleHash"`
 }
 
 type stEnvMarshaling struct {
-	Coinbase         common.UnprefixedAddress
-	Difficulty       *math.HexOrDecimal256
-	Random           *math.HexOrDecimal256
-	ParentDifficulty *math.HexOrDecimal256
-	ParentBaseFee    *math.HexOrDecimal256
-	ParentGasUsed    math.HexOrDecimal64
-	ParentGasLimit   math.HexOrDecimal64
-	GasLimit         math.HexOrDecimal64
-	Number           math.HexOrDecimal64
-	Timestamp        math.HexOrDecimal64
-	ParentTimestamp  math.HexOrDecimal64
-	BaseFee          *math.HexOrDecimal256
+	Coinbase            common.UnprefixedAddress
+	Difficulty          *math.HexOrDecimal256
+	Random              *math.HexOrDecimal256
+	ParentDifficulty    *math.HexOrDecimal256
+	ParentBaseFee       *math.HexOrDecimal256
+	ParentGasUsed       math.HexOrDecimal64
+	ParentGasLimit      math.HexOrDecimal64
+	ParentExcessDataGas *math.HexOrDecimal256
+	GasLimit            math.HexOrDecimal64
+	Number              math.HexOrDecimal64
+	Timestamp           math.HexOrDecimal64
+	ParentTimestamp     math.HexOrDecimal64
+	BaseFee             *math.HexOrDecimal256
+	ExcessDataGas       *math.HexOrDecimal256
 }
 
 type rejectedTx struct {
@@ -154,6 +158,10 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	if pre.Env.Random != nil {
 		rnd := common.BigToHash(pre.Env.Random)
 		vmContext.Random = &rnd
+	}
+	// If excess data gas is defined, add it to vmContext
+	if pre.Env.ExcessDataGas != nil {
+		vmContext.ExcessDataGas = pre.Env.ExcessDataGas
 	}
 	// If DAO is supported/enabled, we need to handle it here. In geth 'proper', it's
 	// done in StateProcessor.Process(block, ...), right before transactions are applied.

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -17,22 +17,24 @@ var _ = (*stEnvMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (s stEnv) MarshalJSON() ([]byte, error) {
 	type stEnv struct {
-		Coinbase         common.UnprefixedAddress            `json:"currentCoinbase"   gencodec:"required"`
-		Difficulty       *math.HexOrDecimal256               `json:"currentDifficulty"`
-		Random           *math.HexOrDecimal256               `json:"currentRandom"`
-		ParentDifficulty *math.HexOrDecimal256               `json:"parentDifficulty"`
-		ParentBaseFee    *math.HexOrDecimal256               `json:"parentBaseFee,omitempty"`
-		ParentGasUsed    math.HexOrDecimal64                 `json:"parentGasUsed,omitempty"`
-		ParentGasLimit   math.HexOrDecimal64                 `json:"parentGasLimit,omitempty"`
-		GasLimit         math.HexOrDecimal64                 `json:"currentGasLimit"   gencodec:"required"`
-		Number           math.HexOrDecimal64                 `json:"currentNumber"     gencodec:"required"`
-		Timestamp        math.HexOrDecimal64                 `json:"currentTimestamp"  gencodec:"required"`
-		ParentTimestamp  math.HexOrDecimal64                 `json:"parentTimestamp,omitempty"`
-		BlockHashes      map[math.HexOrDecimal64]common.Hash `json:"blockHashes,omitempty"`
-		Ommers           []ommer                             `json:"ommers,omitempty"`
-		Withdrawals      []*types.Withdrawal                 `json:"withdrawals,omitempty"`
-		BaseFee          *math.HexOrDecimal256               `json:"currentBaseFee,omitempty"`
-		ParentUncleHash  common.Hash                         `json:"parentUncleHash"`
+		Coinbase            common.UnprefixedAddress            `json:"currentCoinbase"   gencodec:"required"`
+		Difficulty          *math.HexOrDecimal256               `json:"currentDifficulty"`
+		Random              *math.HexOrDecimal256               `json:"currentRandom"`
+		ParentDifficulty    *math.HexOrDecimal256               `json:"parentDifficulty"`
+		ParentBaseFee       *math.HexOrDecimal256               `json:"parentBaseFee,omitempty"`
+		ParentGasUsed       math.HexOrDecimal64                 `json:"parentGasUsed,omitempty"`
+		ParentGasLimit      math.HexOrDecimal64                 `json:"parentGasLimit,omitempty"`
+		ParentExcessDataGas *math.HexOrDecimal256               `json:"parentExcessDataGas,omitempty"`
+		GasLimit            math.HexOrDecimal64                 `json:"currentGasLimit"   gencodec:"required"`
+		Number              math.HexOrDecimal64                 `json:"currentNumber"     gencodec:"required"`
+		Timestamp           math.HexOrDecimal64                 `json:"currentTimestamp"  gencodec:"required"`
+		ParentTimestamp     math.HexOrDecimal64                 `json:"parentTimestamp,omitempty"`
+		BlockHashes         map[math.HexOrDecimal64]common.Hash `json:"blockHashes,omitempty"`
+		Ommers              []ommer                             `json:"ommers,omitempty"`
+		Withdrawals         []*types.Withdrawal                 `json:"withdrawals,omitempty"`
+		BaseFee             *math.HexOrDecimal256               `json:"currentBaseFee,omitempty"`
+		ExcessDataGas       *math.HexOrDecimal256               `json:"currentExcessDataGas,omitempty"`
+		ParentUncleHash     common.Hash                         `json:"parentUncleHash"`
 	}
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
@@ -42,6 +44,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.ParentBaseFee = (*math.HexOrDecimal256)(s.ParentBaseFee)
 	enc.ParentGasUsed = math.HexOrDecimal64(s.ParentGasUsed)
 	enc.ParentGasLimit = math.HexOrDecimal64(s.ParentGasLimit)
+	enc.ParentExcessDataGas = (*math.HexOrDecimal256)(s.ParentExcessDataGas)
 	enc.GasLimit = math.HexOrDecimal64(s.GasLimit)
 	enc.Number = math.HexOrDecimal64(s.Number)
 	enc.Timestamp = math.HexOrDecimal64(s.Timestamp)
@@ -50,6 +53,7 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.Ommers = s.Ommers
 	enc.Withdrawals = s.Withdrawals
 	enc.BaseFee = (*math.HexOrDecimal256)(s.BaseFee)
+	enc.ExcessDataGas = (*math.HexOrDecimal256)(s.ExcessDataGas)
 	enc.ParentUncleHash = s.ParentUncleHash
 	return json.Marshal(&enc)
 }
@@ -57,22 +61,24 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (s *stEnv) UnmarshalJSON(input []byte) error {
 	type stEnv struct {
-		Coinbase         *common.UnprefixedAddress           `json:"currentCoinbase"   gencodec:"required"`
-		Difficulty       *math.HexOrDecimal256               `json:"currentDifficulty"`
-		Random           *math.HexOrDecimal256               `json:"currentRandom"`
-		ParentDifficulty *math.HexOrDecimal256               `json:"parentDifficulty"`
-		ParentBaseFee    *math.HexOrDecimal256               `json:"parentBaseFee,omitempty"`
-		ParentGasUsed    *math.HexOrDecimal64                `json:"parentGasUsed,omitempty"`
-		ParentGasLimit   *math.HexOrDecimal64                `json:"parentGasLimit,omitempty"`
-		GasLimit         *math.HexOrDecimal64                `json:"currentGasLimit"   gencodec:"required"`
-		Number           *math.HexOrDecimal64                `json:"currentNumber"     gencodec:"required"`
-		Timestamp        *math.HexOrDecimal64                `json:"currentTimestamp"  gencodec:"required"`
-		ParentTimestamp  *math.HexOrDecimal64                `json:"parentTimestamp,omitempty"`
-		BlockHashes      map[math.HexOrDecimal64]common.Hash `json:"blockHashes,omitempty"`
-		Ommers           []ommer                             `json:"ommers,omitempty"`
-		Withdrawals      []*types.Withdrawal                 `json:"withdrawals,omitempty"`
-		BaseFee          *math.HexOrDecimal256               `json:"currentBaseFee,omitempty"`
-		ParentUncleHash  *common.Hash                        `json:"parentUncleHash"`
+		Coinbase            *common.UnprefixedAddress           `json:"currentCoinbase"   gencodec:"required"`
+		Difficulty          *math.HexOrDecimal256               `json:"currentDifficulty"`
+		Random              *math.HexOrDecimal256               `json:"currentRandom"`
+		ParentDifficulty    *math.HexOrDecimal256               `json:"parentDifficulty"`
+		ParentBaseFee       *math.HexOrDecimal256               `json:"parentBaseFee,omitempty"`
+		ParentGasUsed       *math.HexOrDecimal64                `json:"parentGasUsed,omitempty"`
+		ParentGasLimit      *math.HexOrDecimal64                `json:"parentGasLimit,omitempty"`
+		ParentExcessDataGas *math.HexOrDecimal256               `json:"parentExcessDataGas,omitempty"`
+		GasLimit            *math.HexOrDecimal64                `json:"currentGasLimit"   gencodec:"required"`
+		Number              *math.HexOrDecimal64                `json:"currentNumber"     gencodec:"required"`
+		Timestamp           *math.HexOrDecimal64                `json:"currentTimestamp"  gencodec:"required"`
+		ParentTimestamp     *math.HexOrDecimal64                `json:"parentTimestamp,omitempty"`
+		BlockHashes         map[math.HexOrDecimal64]common.Hash `json:"blockHashes,omitempty"`
+		Ommers              []ommer                             `json:"ommers,omitempty"`
+		Withdrawals         []*types.Withdrawal                 `json:"withdrawals,omitempty"`
+		BaseFee             *math.HexOrDecimal256               `json:"currentBaseFee,omitempty"`
+		ExcessDataGas       *math.HexOrDecimal256               `json:"currentExcessDataGas,omitempty"`
+		ParentUncleHash     *common.Hash                        `json:"parentUncleHash"`
 	}
 	var dec stEnv
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -100,6 +106,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	if dec.ParentGasLimit != nil {
 		s.ParentGasLimit = uint64(*dec.ParentGasLimit)
 	}
+	if dec.ParentExcessDataGas != nil {
+		s.ParentExcessDataGas = (*big.Int)(dec.ParentExcessDataGas)
+	}
 	if dec.GasLimit == nil {
 		return errors.New("missing required field 'currentGasLimit' for stEnv")
 	}
@@ -126,6 +135,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	}
 	if dec.BaseFee != nil {
 		s.BaseFee = (*big.Int)(dec.BaseFee)
+	}
+	if dec.ExcessDataGas != nil {
+		s.ExcessDataGas = (*big.Int)(dec.ExcessDataGas)
 	}
 	if dec.ParentUncleHash != nil {
 		s.ParentUncleHash = *dec.ParentUncleHash

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -267,14 +267,12 @@ func Transition(ctx *cli.Context) error {
 	}
 	if chainConfig.IsSharding(prestate.Env.Timestamp) {
 		if prestate.Env.ExcessDataGas != nil {
-			// Already set, excess data gas has precedent over parent base fee.
+			// Already set, excess data gas has precedent over parent excess data gas.
 		} else if prestate.Env.ParentExcessDataGas != nil {
 			newBlobs := 0
 			for _, tx := range txs {
-
 				if tx.Type() == types.BlobTxType {
-					hashes, _, _, _ := tx.BlobWrapData()
-					newBlobs += len(hashes)
+					newBlobs += len(tx.DataHashes())
 				}
 			}
 			prestate.Env.ExcessDataGas = misc.CalcExcessDataGas(prestate.Env.ParentExcessDataGas, newBlobs)


### PR DESCRIPTION
Attempt to fix t8n environment parsing under 4844 rules.

There is another error now where we are passing the transaction data to t8n as:
```
{'blobVersionedHashes': ['0x000000000000000000000000000000000000000000000000000000000000002a'],
          'chainId': '0x0',
          'gas': '0x5f5e100',
          'input': '0x0000000000000000000000000000000000000000000000000000000000000000',
          'maxFeePerDataGas': '0xa',
          'maxFeePerGas': '0xa',
          'maxPriorityFeePerGas': '0xa',
          'nonce': '0x0',
          'protected': True,
          'r': '0x0',
          's': '0x0',
          'secretKey': '0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8',
          'to': '0x0000000000000000000000000000000000000100',
          'type': '0x5',
          'v': '0x0',
          'value': '0x0'}
```

But the execution fails because the address recovered during execution is not the same address for the `secretKey` we are passing for some reason:
```
insufficient funds for gas * price + value: address 0xEE74DAe1c8BC99dDFa772e42353A436D21103Ce5 have 0 want 1000131072
```

Correct address is `0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b`.