### PR TITLE
access lists & versioned hashes on blob txs should always be non-nil

### DIFF
--- a/core/types/data_blob_tx.go
+++ b/core/types/data_blob_tx.go
@@ -138,6 +138,8 @@ func (tdv *TxDataView) UnmarshalText(text []byte) error {
 	return conv.DynamicBytesUnmarshalText((*[]byte)(tdv), text[:])
 }
 
+// ReadHashes reads length hashes from dr and returns them through hashes, reusing existing capacity if possible. Hashes will always be
+// non-nil on return.
 func ReadHashes(dr *codec.DecodingReader, hashes *[]common.Hash, length uint64) error {
 	if uint64(len(*hashes)) != length {
 		// re-use space if available (for recycling old state objects)
@@ -146,6 +148,9 @@ func ReadHashes(dr *codec.DecodingReader, hashes *[]common.Hash, length uint64) 
 		} else {
 			*hashes = make([]common.Hash, length)
 		}
+	} else if *hashes == nil {
+		// make sure the output is never nil
+		*hashes = []common.Hash{}
 	}
 	dst := *hashes
 	for i := uint64(0); i < length; i++ {

--- a/core/types/data_blob_tx.go
+++ b/core/types/data_blob_tx.go
@@ -234,6 +234,7 @@ func (atv *AccessTupleView) FixedLength() uint64 {
 type AccessListView AccessList
 
 func (alv *AccessListView) Deserialize(dr *codec.DecodingReader) error {
+	*alv = AccessListView([]AccessTuple{})
 	return dr.List(func() codec.Deserializable {
 		i := len(*alv)
 		*alv = append(*alv, AccessTuple{})

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -296,10 +296,11 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	case BlobTxType:
 		var itx SignedBlobTx
 		inner = &itx
-		// Access list is optional for now.
-		if dec.AccessList != nil {
-			itx.Message.AccessList = AccessListView(*dec.AccessList)
+		// Access list should always be non-nil
+		if dec.AccessList == nil {
+			return errors.New("found nil access list in blob tx")
 		}
+		itx.Message.AccessList = AccessListView(*dec.AccessList)
 		if dec.ChainID == nil {
 			return errors.New("missing required field 'chainId' in transaction")
 		}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -524,17 +524,17 @@ func TestTransactionCoding(t *testing.T) {
 	}
 }
 
-// Make sure deserialized blob transactions never have nil access lists, even when empty.
-func TestBlobTransactionEmptyAccessList(t *testing.T) {
+// Make sure deserialized blob transactions never have nil access lists or versioned hash lists,
+// even when empty.
+func TestBlobTransactionEmptyLists(t *testing.T) {
 	txdata := &SignedBlobTx{
 		Message: BlobTxMessage{
-			ChainID:             view.Uint256View(*uint256.NewInt(1)),
-			Nonce:               view.Uint64View(1),
-			Gas:                 view.Uint64View(123457),
-			GasTipCap:           view.Uint256View(*uint256.NewInt(42)),
-			GasFeeCap:           view.Uint256View(*uint256.NewInt(10)),
-			BlobVersionedHashes: VersionedHashesView{common.HexToHash("0x01624652859a6e98ffc1608e2af0147ca4e86e1ce27672d8d3f3c9d4ffd6ef7e")},
-			MaxFeePerDataGas:    view.Uint256View(*uint256.NewInt(10000000)),
+			ChainID:          view.Uint256View(*uint256.NewInt(1)),
+			Nonce:            view.Uint64View(1),
+			Gas:              view.Uint64View(123457),
+			GasTipCap:        view.Uint256View(*uint256.NewInt(42)),
+			GasFeeCap:        view.Uint256View(*uint256.NewInt(10)),
+			MaxFeePerDataGas: view.Uint256View(*uint256.NewInt(10000000)),
 		},
 	}
 	tx := NewTx(txdata)
@@ -548,6 +548,9 @@ func TestBlobTransactionEmptyAccessList(t *testing.T) {
 	}
 	if parsedTx.AccessList() == nil {
 		t.Fatal("Deserialized blob txs should have non-nil access lists")
+	}
+	if parsedTx.DataHashes() == nil {
+		t.Fatal("Deserialized blob txs should have non-nil versioned hash lists")
 	}
 }
 


### PR DESCRIPTION
These fields are non-optional and hence should always be empty lists instead of nil.
