### PR TITLE
Fix EIP-4844 Signer  hash

### DIFF
--- a/core/types/data_blob_tx.go
+++ b/core/types/data_blob_tx.go
@@ -295,6 +295,10 @@ func (tx *BlobTxMessage) FixedLength() uint64 {
 	return 0
 }
 
+func (tx *BlobTxMessage) setChainID(chainID *big.Int) {
+	(*uint256.Int)(&tx.ChainID).SetFromBig(chainID)
+}
+
 func (stx *SignedBlobTx) ByteLength() uint64 {
 	return codec.ContainerLength(&stx.Message, &stx.Signature)
 }
@@ -378,7 +382,7 @@ func (stx *SignedBlobTx) rawSignatureValues() (v, r, s *big.Int) {
 }
 
 func (stx *SignedBlobTx) setSignatureValues(chainID, v, r, s *big.Int) {
-	(*uint256.Int)(&stx.Message.ChainID).SetFromBig(chainID)
+	stx.Message.setChainID(chainID)
 	stx.Signature.V = Uint8View(v.Uint64())
 	(*uint256.Int)(&stx.Signature.R).SetFromBig(r)
 	(*uint256.Int)(&stx.Signature.S).SetFromBig(s)

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -229,7 +229,9 @@ func (s dankSigner) Hash(tx *Transaction) common.Hash {
 	if tx.Type() != BlobTxType {
 		return s.londonSigner.Hash(tx)
 	}
-	return prefixedSSZHash(BlobTxType, &tx.inner.(*SignedBlobTx).Message)
+	messageSigning := tx.inner.(*SignedBlobTx).Message
+	messageSigning.setChainID(s.chainId)
+	return prefixedSSZHash(BlobTxType, &messageSigning)
 }
 
 type londonSigner struct{ eip2930Signer }


### PR DESCRIPTION
Ensures that the EIP-4844 Signer (DankSigner) includes the appropriate chainID to the signing hash.

This way users don't have to preconfigure the ChainID in the BlobTxMessage to create a properly signed message.