### PR TITLE
cmd/evm: fix `excessDataGas` marshalling in b11r

### DIFF
--- a/cmd/evm/internal/t8ntool/block.go
+++ b/cmd/evm/internal/t8ntool/block.go
@@ -59,13 +59,14 @@ type header struct {
 }
 
 type headerMarshaling struct {
-	Difficulty *math.HexOrDecimal256
-	Number     *math.HexOrDecimal256
-	GasLimit   math.HexOrDecimal64
-	GasUsed    math.HexOrDecimal64
-	Time       math.HexOrDecimal64
-	Extra      hexutil.Bytes
-	BaseFee    *math.HexOrDecimal256
+	Difficulty    *math.HexOrDecimal256
+	Number        *math.HexOrDecimal256
+	GasLimit      math.HexOrDecimal64
+	GasUsed       math.HexOrDecimal64
+	Time          math.HexOrDecimal64
+	Extra         hexutil.Bytes
+	BaseFee       *math.HexOrDecimal256
+	ExcessDataGas *math.HexOrDecimal256
 }
 
 type bbInput struct {

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -289,23 +289,22 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		return nil, nil, NewError(ErrorEVM, fmt.Errorf("could not commit state: %v", err))
 	}
 	execRs := &ExecutionResult{
-		StateRoot:     root,
-		TxRoot:        types.DeriveSha(includedTxs, trie.NewStackTrie(nil)),
-		ReceiptRoot:   types.DeriveSha(receipts, trie.NewStackTrie(nil)),
-		Bloom:         types.CreateBloom(receipts),
-		LogsHash:      rlpHash(statedb.Logs()),
-		Receipts:      receipts,
-		Rejected:      rejectedTxs,
-		Difficulty:    (*math.HexOrDecimal256)(vmContext.Difficulty),
-		GasUsed:       (math.HexOrDecimal64)(gasUsed),
-		BaseFee:       (*math.HexOrDecimal256)(vmContext.BaseFee),
-		ExcessDataGas: (*math.HexOrDecimal256)(vmContext.ExcessDataGas),
+		StateRoot:   root,
+		TxRoot:      types.DeriveSha(includedTxs, trie.NewStackTrie(nil)),
+		ReceiptRoot: types.DeriveSha(receipts, trie.NewStackTrie(nil)),
+		Bloom:       types.CreateBloom(receipts),
+		LogsHash:    rlpHash(statedb.Logs()),
+		Receipts:    receipts,
+		Rejected:    rejectedTxs,
+		Difficulty:  (*math.HexOrDecimal256)(vmContext.Difficulty),
+		GasUsed:     (math.HexOrDecimal64)(gasUsed),
+		BaseFee:     (*math.HexOrDecimal256)(vmContext.BaseFee),
 	}
 	if pre.Env.Withdrawals != nil {
 		h := types.DeriveSha(types.Withdrawals(pre.Env.Withdrawals), trie.NewStackTrie(nil))
 		execRs.WithdrawalsRoot = &h
 	}
-	if pre.Env.ParentExcessDataGas != nil {
+	if vmContext.ExcessDataGas != nil {
 		// calculate and set the excess data gas at the end of this block execution
 		newBlobs := 0
 		for _, tx := range txs {
@@ -313,7 +312,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 				newBlobs += len(tx.DataHashes())
 			}
 		}
-		execRs.ExcessDataGas = (*math.HexOrDecimal256)(misc.CalcExcessDataGas(pre.Env.ParentExcessDataGas, newBlobs))
+		execRs.ExcessDataGas = (*math.HexOrDecimal256)(misc.CalcExcessDataGas(vmContext.ExcessDataGas, newBlobs))
 	}
 	return statedb, execRs, nil
 }

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -58,6 +58,7 @@ type ExecutionResult struct {
 	GasUsed         math.HexOrDecimal64   `json:"gasUsed"`
 	BaseFee         *math.HexOrDecimal256 `json:"currentBaseFee,omitempty"`
 	WithdrawalsRoot *common.Hash          `json:"withdrawalsRoot,omitempty"`
+	ExcessDataGas   *math.HexOrDecimal256 `json:"currentExcessDataGas,omitempty"`
 }
 
 type ommer struct {
@@ -286,16 +287,17 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		return nil, nil, NewError(ErrorEVM, fmt.Errorf("could not commit state: %v", err))
 	}
 	execRs := &ExecutionResult{
-		StateRoot:   root,
-		TxRoot:      types.DeriveSha(includedTxs, trie.NewStackTrie(nil)),
-		ReceiptRoot: types.DeriveSha(receipts, trie.NewStackTrie(nil)),
-		Bloom:       types.CreateBloom(receipts),
-		LogsHash:    rlpHash(statedb.Logs()),
-		Receipts:    receipts,
-		Rejected:    rejectedTxs,
-		Difficulty:  (*math.HexOrDecimal256)(vmContext.Difficulty),
-		GasUsed:     (math.HexOrDecimal64)(gasUsed),
-		BaseFee:     (*math.HexOrDecimal256)(vmContext.BaseFee),
+		StateRoot:     root,
+		TxRoot:        types.DeriveSha(includedTxs, trie.NewStackTrie(nil)),
+		ReceiptRoot:   types.DeriveSha(receipts, trie.NewStackTrie(nil)),
+		Bloom:         types.CreateBloom(receipts),
+		LogsHash:      rlpHash(statedb.Logs()),
+		Receipts:      receipts,
+		Rejected:      rejectedTxs,
+		Difficulty:    (*math.HexOrDecimal256)(vmContext.Difficulty),
+		GasUsed:       (math.HexOrDecimal64)(gasUsed),
+		BaseFee:       (*math.HexOrDecimal256)(vmContext.BaseFee),
+		ExcessDataGas: (*math.HexOrDecimal256)(vmContext.ExcessDataGas),
 	}
 	if pre.Env.Withdrawals != nil {
 		h := types.DeriveSha(types.Withdrawals(pre.Env.Withdrawals), trie.NewStackTrie(nil))

--- a/cmd/evm/internal/t8ntool/gen_header.go
+++ b/cmd/evm/internal/t8ntool/gen_header.go
@@ -35,7 +35,7 @@ func (h header) MarshalJSON() ([]byte, error) {
 		Nonce           *types.BlockNonce     `json:"nonce"`
 		BaseFee         *math.HexOrDecimal256 `json:"baseFeePerGas" rlp:"optional"`
 		WithdrawalsHash *common.Hash          `json:"withdrawalsRoot" rlp:"optional"`
-		ExcessDataGas   *big.Int              `json:"excessDataGas"   rlp:"optional"`
+		ExcessDataGas   *math.HexOrDecimal256 `json:"excessDataGas"   rlp:"optional"`
 	}
 	var enc header
 	enc.ParentHash = h.ParentHash
@@ -55,7 +55,7 @@ func (h header) MarshalJSON() ([]byte, error) {
 	enc.Nonce = h.Nonce
 	enc.BaseFee = (*math.HexOrDecimal256)(h.BaseFee)
 	enc.WithdrawalsHash = h.WithdrawalsHash
-	enc.ExcessDataGas = h.ExcessDataGas
+	enc.ExcessDataGas = (*math.HexOrDecimal256)(h.ExcessDataGas)
 	return json.Marshal(&enc)
 }
 
@@ -79,7 +79,7 @@ func (h *header) UnmarshalJSON(input []byte) error {
 		Nonce           *types.BlockNonce     `json:"nonce"`
 		BaseFee         *math.HexOrDecimal256 `json:"baseFeePerGas" rlp:"optional"`
 		WithdrawalsHash *common.Hash          `json:"withdrawalsRoot" rlp:"optional"`
-		ExcessDataGas   *big.Int              `json:"excessDataGas"   rlp:"optional"`
+		ExcessDataGas   *math.HexOrDecimal256 `json:"excessDataGas"   rlp:"optional"`
 	}
 	var dec header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -141,7 +141,7 @@ func (h *header) UnmarshalJSON(input []byte) error {
 		h.WithdrawalsHash = dec.WithdrawalsHash
 	}
 	if dec.ExcessDataGas != nil {
-		h.ExcessDataGas = dec.ExcessDataGas
+		h.ExcessDataGas = (*big.Int)(dec.ExcessDataGas)
 	}
 	return nil
 }

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -33,7 +33,6 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 		Ommers              []ommer                             `json:"ommers,omitempty"`
 		Withdrawals         []*types.Withdrawal                 `json:"withdrawals,omitempty"`
 		BaseFee             *math.HexOrDecimal256               `json:"currentBaseFee,omitempty"`
-		ExcessDataGas       *math.HexOrDecimal256               `json:"currentExcessDataGas,omitempty"`
 		ParentUncleHash     common.Hash                         `json:"parentUncleHash"`
 	}
 	var enc stEnv
@@ -53,7 +52,6 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.Ommers = s.Ommers
 	enc.Withdrawals = s.Withdrawals
 	enc.BaseFee = (*math.HexOrDecimal256)(s.BaseFee)
-	enc.ExcessDataGas = (*math.HexOrDecimal256)(s.ExcessDataGas)
 	enc.ParentUncleHash = s.ParentUncleHash
 	return json.Marshal(&enc)
 }
@@ -77,7 +75,6 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 		Ommers              []ommer                             `json:"ommers,omitempty"`
 		Withdrawals         []*types.Withdrawal                 `json:"withdrawals,omitempty"`
 		BaseFee             *math.HexOrDecimal256               `json:"currentBaseFee,omitempty"`
-		ExcessDataGas       *math.HexOrDecimal256               `json:"currentExcessDataGas,omitempty"`
 		ParentUncleHash     *common.Hash                        `json:"parentUncleHash"`
 	}
 	var dec stEnv
@@ -135,9 +132,6 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	}
 	if dec.BaseFee != nil {
 		s.BaseFee = (*big.Int)(dec.BaseFee)
-	}
-	if dec.ExcessDataGas != nil {
-		s.ExcessDataGas = (*big.Int)(dec.ExcessDataGas)
 	}
 	if dec.ParentUncleHash != nil {
 		s.ParentUncleHash = *dec.ParentUncleHash

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -265,19 +265,6 @@ func Transition(ctx *cli.Context) error {
 	if chainConfig.IsShanghai(prestate.Env.Number) && prestate.Env.Withdrawals == nil {
 		return NewError(ErrorConfig, errors.New("Shanghai config but missing 'withdrawals' in env section"))
 	}
-	if chainConfig.IsSharding(prestate.Env.Timestamp) {
-		if prestate.Env.ExcessDataGas != nil {
-			// Already set, excess data gas has precedent over parent excess data gas.
-		} else if prestate.Env.ParentExcessDataGas != nil {
-			newBlobs := 0
-			for _, tx := range txs {
-				if tx.Type() == types.BlobTxType {
-					newBlobs += len(tx.DataHashes())
-				}
-			}
-			prestate.Env.ExcessDataGas = misc.CalcExcessDataGas(prestate.Env.ParentExcessDataGas, newBlobs)
-		}
-	}
 	isMerged := chainConfig.TerminalTotalDifficulty != nil && chainConfig.TerminalTotalDifficulty.BitLen() == 0
 	env := prestate.Env
 	if isMerged {

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -89,6 +89,7 @@ type btHeader struct {
 	Timestamp        uint64
 	BaseFeePerGas    *big.Int
 	WithdrawalsRoot  *common.Hash
+	ExcessDataGas    *big.Int
 }
 
 type btHeaderMarshaling struct {
@@ -99,6 +100,7 @@ type btHeaderMarshaling struct {
 	GasUsed       math.HexOrDecimal64
 	Timestamp     math.HexOrDecimal64
 	BaseFeePerGas *math.HexOrDecimal256
+	ExcessDataGas *math.HexOrDecimal256
 }
 
 func (t *BlockTest) Run(snapshotter bool) error {
@@ -163,18 +165,19 @@ func (t *BlockTest) Run(snapshotter bool) error {
 
 func (t *BlockTest) genesis(config *params.ChainConfig) *core.Genesis {
 	return &core.Genesis{
-		Config:     config,
-		Nonce:      t.json.Genesis.Nonce.Uint64(),
-		Timestamp:  t.json.Genesis.Timestamp,
-		ParentHash: t.json.Genesis.ParentHash,
-		ExtraData:  t.json.Genesis.ExtraData,
-		GasLimit:   t.json.Genesis.GasLimit,
-		GasUsed:    t.json.Genesis.GasUsed,
-		Difficulty: t.json.Genesis.Difficulty,
-		Mixhash:    t.json.Genesis.MixHash,
-		Coinbase:   t.json.Genesis.Coinbase,
-		Alloc:      t.json.Pre,
-		BaseFee:    t.json.Genesis.BaseFeePerGas,
+		Config:        config,
+		Nonce:         t.json.Genesis.Nonce.Uint64(),
+		Timestamp:     t.json.Genesis.Timestamp,
+		ParentHash:    t.json.Genesis.ParentHash,
+		ExtraData:     t.json.Genesis.ExtraData,
+		GasLimit:      t.json.Genesis.GasLimit,
+		GasUsed:       t.json.Genesis.GasUsed,
+		Difficulty:    t.json.Genesis.Difficulty,
+		Mixhash:       t.json.Genesis.MixHash,
+		Coinbase:      t.json.Genesis.Coinbase,
+		Alloc:         t.json.Pre,
+		BaseFee:       t.json.Genesis.BaseFeePerGas,
+		ExcessDataGas: t.json.Genesis.ExcessDataGas,
 	}
 }
 
@@ -282,6 +285,9 @@ func validateHeader(h *btHeader, h2 *types.Header) error {
 	}
 	if !reflect.DeepEqual(h.WithdrawalsRoot, h2.WithdrawalsHash) {
 		return fmt.Errorf("withdrawalsRoot: want: %v have: %v", h.WithdrawalsRoot, h2.WithdrawalsHash)
+	}
+	if !reflect.DeepEqual(h.ExcessDataGas, h2.ExcessDataGas) {
+		return fmt.Errorf("excessDataGas: want: %v have: %v", h.ExcessDataGas, h2.ExcessDataGas)
 	}
 	return nil
 }

--- a/tests/gen_btheader.go
+++ b/tests/gen_btheader.go
@@ -35,6 +35,7 @@ func (b btHeader) MarshalJSON() ([]byte, error) {
 		Timestamp        math.HexOrDecimal64
 		BaseFeePerGas    *math.HexOrDecimal256
 		WithdrawalsRoot  *common.Hash
+		ExcessDataGas    *math.HexOrDecimal256
 	}
 	var enc btHeader
 	enc.Bloom = b.Bloom
@@ -55,6 +56,7 @@ func (b btHeader) MarshalJSON() ([]byte, error) {
 	enc.Timestamp = math.HexOrDecimal64(b.Timestamp)
 	enc.BaseFeePerGas = (*math.HexOrDecimal256)(b.BaseFeePerGas)
 	enc.WithdrawalsRoot = b.WithdrawalsRoot
+	enc.ExcessDataGas = (*math.HexOrDecimal256)(b.ExcessDataGas)
 	return json.Marshal(&enc)
 }
 
@@ -79,6 +81,7 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 		Timestamp        *math.HexOrDecimal64
 		BaseFeePerGas    *math.HexOrDecimal256
 		WithdrawalsRoot  *common.Hash
+		ExcessDataGas    *math.HexOrDecimal256
 	}
 	var dec btHeader
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -137,6 +140,9 @@ func (b *btHeader) UnmarshalJSON(input []byte) error {
 	}
 	if dec.WithdrawalsRoot != nil {
 		b.WithdrawalsRoot = dec.WithdrawalsRoot
+	}
+	if dec.ExcessDataGas != nil {
+		b.ExcessDataGas = (*big.Int)(dec.ExcessDataGas)
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes Included
- Fixes marshalling of field `excessDataGas` when parsing header to construct the RLP of the block in `evm b11r` tool
- Fixes marshalling of field `excessDataGas` when parsing blockchain tests json files
- Removes `currentExcessDataGas` from t8n environment input (only `parentExcessDataGas` is used as input now), but calculates and prints the correct value in the result.