### PR TITLE
Updates to latest gnark which now uses derived types instead of type aliases

### DIFF
--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -266,18 +266,18 @@ func (blobs Blobs) ComputeCommitmentsAndProofs() (commitments []KZGCommitment, v
 	versionedHashes = make([]common.Hash, len(blobs))
 
 	for i, blob := range blobs {
-		commitment, err := kzg.CryptoCtx.BlobToKZGCommitment(blob)
+		commitment, err := kzg.CryptoCtx.BlobToKZGCommitment(serialization.Blob(blob))
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not convert blob to commitment: %v", err)
 		}
 
-		proof, err := kzg.CryptoCtx.ComputeBlobKZGProof(blob, commitment)
+		proof, err := kzg.CryptoCtx.ComputeBlobKZGProof(serialization.Blob(blob), commitment)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("could not compute proof for blob: %v", err)
 		}
 		commitments[i] = KZGCommitment(commitment)
 		proofs[i] = KZGProof(proof)
-		versionedHashes[i] = common.Hash(kzg.KZGToVersionedHash(commitment))
+		versionedHashes[i] = common.Hash(kzg.KZGToVersionedHash(serialization.KZGCommitment(commitment)))
 	}
 
 	return commitments, versionedHashes, proofs, nil

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 )
 
-require github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230312204821-9a244123c812
+require github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322233247-22e22c6f68e6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,12 @@ github.com/crate-crypto/go-ipa v0.0.0-20220523130400-f11357ae11c7 h1:6IrxszG5G+O
 github.com/crate-crypto/go-ipa v0.0.0-20220523130400-f11357ae11c7/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230312204821-9a244123c812 h1:fvpzeIO449sb44y2Nqd0MVziJHvp0OFCG66t3ZjuYqU=
 github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230312204821-9a244123c812/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322232037-070b0b94db8a h1:LWAQVosZamsfhvO14tfYNMluSHTWXF6AKa+9DmaK7Q0=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322232037-070b0b94db8a/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322232628-fbbf54e10131 h1:/ZBvP82vNl+xWYfcAHewbjRkq1MS2l0DKyeIWO4wgME=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322232628-fbbf54e10131/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322233247-22e22c6f68e6 h1:KguBkZjb4BXvSmVxjugrmJQyGjZqZHJfGHMmHgZn6ls=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322233247-22e22c6f68e6/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
The KZGCommitment/Blob/KZGProofs now use derived types instead of type aliases