### PR TITLE
Use the exported ZERO point from gnark-kzg

### DIFF
--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/crate-crypto/go-proto-danksharding-crypto/api"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -96,12 +97,10 @@ func TestEIP4844Signing(t *testing.T) {
 			BlobVersionedHashes: VersionedHashesView{common.HexToHash("0x010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014")},
 		},
 	}
-	// This is the identity point serialised
-	var kzgProof KZGProof = [48]byte{192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	wrapData := &BlobTxWrapData{
 		BlobKzgs: BlobKzgs{KZGCommitment{0: 0xc0}},
 		Blobs:    Blobs{Blob{}},
-		Proofs:   KZGProofs{kzgProof},
+		Proofs:   KZGProofs{api.ZERO_POINT},
 	}
 	tx := NewTx(txdata, WithTxWrapData(wrapData))
 	tx, err := SignTx(tx, signer, key)

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crate-crypto/go-proto-danksharding-crypto/api"
 	"github.com/holiman/uint256"
 	"github.com/protolambda/ztyp/view"
 
@@ -492,12 +493,10 @@ func TestTransactionCoding(t *testing.T) {
 					BlobVersionedHashes: VersionedHashesView{common.HexToHash("0x010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014")},
 				},
 			}
-			// This is the identity point serialised
-			var kzgProof KZGProof = [48]byte{192, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 			wrapData = &BlobTxWrapData{
 				BlobKzgs: BlobKzgs{KZGCommitment{0: 0xc0}},
 				Blobs:    Blobs{Blob{}},
-				Proofs:   KZGProofs{kzgProof},
+				Proofs:   KZGProofs{api.ZERO_POINT},
 			}
 		}
 		tx, err := SignNewTx(key, signer, txdata, WithTxWrapData(wrapData))

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 )
 
-require github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322233247-22e22c6f68e6
+require github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230325161441-829bf646183d
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322232628-fbbf5
 github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322232628-fbbf54e10131/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
 github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322233247-22e22c6f68e6 h1:KguBkZjb4BXvSmVxjugrmJQyGjZqZHJfGHMmHgZn6ls=
 github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230322233247-22e22c6f68e6/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230325161441-829bf646183d h1:rFbq+iU1Evnzs//EjFY7bUcIn4+/gdczDfx+PSMmvTE=
+github.com/crate-crypto/go-proto-danksharding-crypto v0.0.0-20230325161441-829bf646183d/go.mod h1:ZNzUrSnC7IXKtQWnROzWVfQSivVSCPkMtwXekLDj4qI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
This PR updates snark-kzg and uses the exposed ZERO_POINT instead of the hardcoded constant in tests