### PR TITLE
cmd/evm: change tx signer to latest

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -241,7 +241,7 @@ func Transition(ctx *cli.Context) error {
 		}
 	}
 	// We may have to sign the transactions.
-	signer := types.MakeSigner(chainConfig, big.NewInt(int64(prestate.Env.Number)), prestate.Env.Timestamp)
+	signer := types.LatestSignerForChainID(chainConfig.ChainID)
 
 	if txs, err = signUnsignedTransactions(txsWithKeys, signer); err != nil {
 		return NewError(ErrorJson, fmt.Errorf("failed signing transactions: %v", err))


### PR DESCRIPTION
## Changes Included
- Use the latest signer which is more permissive to sign transactions in a transition test.
- Allows us to, e.g., create tests that add a type-5 tx in a pre-Sharding (Cancun) fork block.