### PR TITLE
properly unify payload/blob returning in API, add proofs to blob bundle, reject 0-blob blob txs

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -44,8 +44,9 @@ type payloadAttributesMarshaling struct {
 
 // BlobsBundle holds the blobs of an execution payload
 type BlobsBundle struct {
-	KZGs  []types.KZGCommitment `json:"kzgs"  gencodec:"required"`
-	Blobs []types.Blob          `json:"blobs" gencodec:"required"`
+	KZGs   []types.KZGCommitment `json:"kzgs"   gencodec:"required"`
+	Blobs  []types.Blob          `json:"blobs"  gencodec:"required"`
+	Proofs []types.KZGProof      `json:"proofs" gencodec:"required"`
 }
 
 //go:generate go run github.com/fjl/gencodec -type ExecutableData -field-override executableDataMarshaling -out gen_ed.go
@@ -249,8 +250,9 @@ type ExecutionPayloadBodyV1 struct {
 
 func BlockToBlobData(block *types.Block) (*BlobsBundle, error) {
 	blobsBundle := &BlobsBundle{
-		Blobs: []types.Blob{},
-		KZGs:  []types.KZGCommitment{},
+		Blobs:  []types.Blob{},
+		KZGs:   []types.KZGCommitment{},
+		Proofs: []types.KZGProof{},
 	}
 	for i, tx := range block.Transactions() {
 		if tx.Type() == types.BlobTxType {
@@ -262,6 +264,7 @@ func BlockToBlobData(block *types.Block) (*BlobsBundle, error) {
 
 			blobsBundle.Blobs = append(blobsBundle.Blobs, blobs...)
 			blobsBundle.KZGs = append(blobsBundle.KZGs, kzgs...)
+			blobsBundle.Proofs = append(blobsBundle.Proofs, proofs...)
 		}
 	}
 	return blobsBundle, nil

--- a/core/types/data_blob.go
+++ b/core/types/data_blob.go
@@ -346,8 +346,11 @@ func (b *BlobTxWrapData) validateBlobTransactionWrapper(inner TxData) error {
 	if !ok {
 		return fmt.Errorf("expected signed blob tx, got %T", inner)
 	}
-	l1 := len(b.BlobKzgs)
-	l2 := len(blobTx.Message.BlobVersionedHashes)
+	l1 := len(blobTx.Message.BlobVersionedHashes)
+	if l1 == 0 {
+		return errors.New("blob transactions must have at least one blob")
+	}
+	l2 := len(b.BlobKzgs)
 	l3 := len(b.Blobs)
 	l4 := len(b.Proofs)
 	if l1 != l2 || l1 != l3 || l1 != l4 {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -423,18 +423,13 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID) (*engine.Executi
 
 // GetPayloadV3 returns a cached payload by id.
 func (api *ConsensusAPI) GetPayloadV3(payloadID engine.PayloadID) (*engine.ExecutionPayloadEnvelope, error) {
-	pl, err := api.GetPayloadV2(payloadID)
+	pl, err := api.localBlocks.getPayloadWithBlobsBundle(payloadID)
 	if err != nil {
 		return nil, err
 	}
-	data, err := api.localBlocks.getBlobsBundle(payloadID)
-	if err != nil {
-		return nil, err
-	}
-	if data == nil {
+	if pl == nil {
 		return nil, engine.UnknownPayload
 	}
-	pl.BlobsBundle = data
 	return pl, nil
 }
 

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -88,8 +88,9 @@ func (q *payloadQueue) get(id engine.PayloadID) *engine.ExecutionPayloadEnvelope
 	return nil
 }
 
-// get retrieves a previously stored blobs bundle item or nil if it does not exist.
-func (q *payloadQueue) getBlobsBundle(id engine.PayloadID) (*engine.BlobsBundle, error) {
+// get retrieves a previously stored payload along with its blobs bundle, or nil if it does not
+// exist.
+func (q *payloadQueue) getPayloadWithBlobsBundle(id engine.PayloadID) (*engine.ExecutionPayloadEnvelope, error) {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
@@ -98,7 +99,7 @@ func (q *payloadQueue) getBlobsBundle(id engine.PayloadID) (*engine.BlobsBundle,
 			return nil, nil // no more items
 		}
 		if item.id == id {
-			return item.payload.ResolveToBlobsBundle()
+			return item.payload.ResolveWithBlobsBundle()
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
- Removes potential race condition when returning a payload with its blobs
- adds proofs to blobs bundle per https://github.com/ethereum/execution-apis/pull/392/files
- bans 0-blob txs per https://github.com/ethereum/EIPs/pull/6863/files