### PR TITLE
Trigger EIP-4844 on Cancun fork

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -160,7 +160,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		vmContext.Random = &rnd
 	}
 	// If excess data gas is defined, add it to vmContext
-	if chainConfig.IsSharding(pre.Env.Timestamp) {
+	if chainConfig.IsCancun(pre.Env.Timestamp) {
 		if pre.Env.ParentExcessDataGas != nil {
 			vmContext.ExcessDataGas = pre.Env.ParentExcessDataGas
 		} else {

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -269,8 +269,8 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		return fmt.Errorf("invalid withdrawalsHash: have %x, expected nil", header.WithdrawalsHash)
 	}
 	// Verify existence / non-existence of excessDataGas.
-	sharding := chain.Config().IsSharding(header.Time)
-	if sharding {
+	cancun := chain.Config().IsCancun(header.Time)
+	if cancun {
 		if header.ExcessDataGas == nil {
 			return fmt.Errorf("missing excessDataGas")
 		}
@@ -279,7 +279,7 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 			return err
 		}
 	}
-	if !sharding && header.ExcessDataGas != nil {
+	if !cancun && header.ExcessDataGas != nil {
 		return fmt.Errorf("invalied ExcessDataGas: have %v, expected nil", header.ExcessDataGas)
 	}
 	return nil
@@ -358,7 +358,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	// The block reward is no longer handled here. It's done by the
 	// external consensus engine.
 	header.Root = state.IntermediateRoot(true)
-	if chain.Config().IsSharding(header.Time) {
+	if chain.Config().IsCancun(header.Time) {
 		if parent := chain.GetHeaderByHash(header.ParentHash); parent != nil {
 			header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
 		} else {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -348,7 +348,7 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 		// Verify the header's EIP-1559 attributes.
 		return err
 	}
-	if !chain.Config().IsSharding(header.Time) {
+	if !chain.Config().IsCancun(header.Time) {
 		if header.ExcessDataGas != nil {
 			return fmt.Errorf("invalid excessDataGas before fork: have %v, want <nil>", header.ExcessDataGas)
 		}
@@ -579,7 +579,7 @@ func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 	// No block rewards in PoA, so the state remains as is and uncles are dropped
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)
-	if chain.Config().IsSharding(header.Time) {
+	if chain.Config().IsCancun(header.Time) {
 		if parent := chain.GetHeaderByHash(header.ParentHash); parent != nil {
 			header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
 		} else {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -306,7 +306,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		// Verify the header's EIP-1559 attributes.
 		return err
 	}
-	if !chain.Config().IsSharding(header.Time) {
+	if !chain.Config().IsCancun(header.Time) {
 		if header.ExcessDataGas != nil {
 			return fmt.Errorf("invalid excessDataGas before fork: have %v, expected 'nil'", header.ExcessDataGas)
 		}
@@ -612,7 +612,7 @@ func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
-	if chain.Config().IsSharding(header.Time) {
+	if chain.Config().IsCancun(header.Time) {
 		if parent := chain.GetHeaderByHash(header.ParentHash); parent != nil {
 			header.SetExcessDataGas(misc.CalcExcessDataGas(parent.ExcessDataGas, misc.CountBlobs(txs)))
 		} else {

--- a/consensus/misc/eip4844.go
+++ b/consensus/misc/eip4844.go
@@ -63,7 +63,7 @@ func VerifyEip4844Header(config *params.ChainConfig, parent, header *types.Heade
 // VerifyExcessDataGas verifies the excess_data_gas in the block header
 func VerifyExcessDataGas(chainReader ChainReader, block *types.Block) error {
 	excessDataGas := block.ExcessDataGas()
-	if !chainReader.Config().IsSharding(block.Time()) {
+	if !chainReader.Config().IsCancun(block.Time()) {
 		if excessDataGas != nil {
 			return fmt.Errorf("unexpected excessDataGas in header")
 		}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4178,22 +4178,22 @@ func TestDataBlobTxs(t *testing.T) {
 		}
 	)
 
-	// We test the transition from non-sharding to sharding
+	// We test the transition from non-cancun to cancun
 	// Genesis (block 0): AllEthhashProtocolChanges
 	// Block 1          : ""
-	// Block 2          : Sharding
+	// Block 2          : Cancun
 	var time uint64 = 2 * 10 // block time is 10 seconds, so this corresponds to second block.
 	gspec.Config.BerlinBlock = common.Big0
 	gspec.Config.LondonBlock = common.Big0
 	gspec.Config.ShanghaiTime = &time
-	gspec.Config.ShardingForkTime = &time
+	gspec.Config.CancunTime = &time
 	gspec.Config.TerminalTotalDifficulty = common.Big0
 	gspec.Config.TerminalTotalDifficultyPassed = true
 	signer := types.LatestSigner(gspec.Config)
 
 	_, blocks, _ := GenerateChainWithGenesis(gspec, engine, 2, func(i int, b *BlockGen) {
 		if i == 0 {
-			// i==0 is a non-sharding block
+			// i==0 is a non-cancun block
 			return
 		}
 		b.SetCoinbase(common.Address{1})

--- a/core/evm.go
+++ b/core/evm.go
@@ -58,7 +58,7 @@ func NewEVMBlockContext(header *types.Header, excessDataGas *big.Int, chain Chai
 	if header.Difficulty.Cmp(common.Big0) == 0 {
 		random = &header.MixDigest
 	}
-	// In the event excessDataGas is nil (which happens if the parent block is pre-sharding),
+	// In the event excessDataGas is nil (which happens if the parent block is pre-cancun),
 	// we bootstrap BlockContext.ExcessDataGas with the zero value.
 	edg := new(big.Int)
 	if excessDataGas != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -471,7 +471,7 @@ func (g *Genesis) ToBlock() *types.Block {
 		if g.Config.IsShanghai(g.Timestamp) {
 			head.WithdrawalsHash = &types.EmptyRootHash
 		}
-		if g.Config.IsSharding(g.Timestamp) {
+		if g.Config.IsCancun(g.Timestamp) {
 			head.SetExcessDataGas(g.ExcessDataGas)
 		}
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -236,10 +236,10 @@ func (st *StateTransition) buyGas() error {
 	// compute data fee for eip-4844 data blobs if any
 	dgval := new(big.Int)
 	var dataGasUsed uint64
-	if st.evm.ChainConfig().IsSharding(st.evm.Context.Time) {
+	if st.evm.ChainConfig().IsCancun(st.evm.Context.Time) {
 		dataGasUsed = st.dataGasUsed()
 		if st.evm.Context.ExcessDataGas == nil {
-			return fmt.Errorf("%w: sharding is active but ExcessDataGas is nil. Time: %v", ErrInternalFailure, st.evm.Context.Time)
+			return fmt.Errorf("%w: cancun is active but ExcessDataGas is nil. Time: %v", ErrInternalFailure, st.evm.Context.Time)
 		}
 		dgval.Mul(types.GetDataGasPrice(st.evm.Context.ExcessDataGas), new(big.Int).SetUint64(dataGasUsed))
 	}
@@ -323,7 +323,7 @@ func (st *StateTransition) preCheck() error {
 			}
 		}
 	}
-	if st.dataGasUsed() > 0 && st.evm.ChainConfig().IsSharding(st.evm.Context.Time) {
+	if st.dataGasUsed() > 0 && st.evm.ChainConfig().IsCancun(st.evm.Context.Time) {
 		dataGasPrice := types.GetDataGasPrice(st.evm.Context.ExcessDataGas)
 		if dataGasPrice.Cmp(st.msg.MaxFeePerDataGas) > 0 {
 			return fmt.Errorf("%w: address %v, maxFeePerDataGas: %v dataGasPrice: %v, excessDataGas: %v",

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1490,7 +1490,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
 	now := uint64(time.Now().Unix())
 	pool.shanghai = pool.chainconfig.IsShanghai(now)
-	pool.eip4844 = pool.chainconfig.IsSharding(now)
+	pool.eip4844 = pool.chainconfig.IsCancun(now)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/txpool/txpool_test.go
+++ b/core/txpool/txpool_test.go
@@ -60,7 +60,7 @@ func init() {
 	eip1559Config.BerlinBlock = common.Big0
 	eip1559Config.LondonBlock = common.Big0
 	var zeroTime uint64
-	eip1559Config.ShardingForkTime = &zeroTime // for blob tx tests
+	eip1559Config.CancunTime = &zeroTime // for blob tx tests
 }
 
 type testBlockChain struct {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,7 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, time uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsSharding(time):
+	case config.IsCancun(time):
 		signer = NewDankSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -65,7 +65,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, time uint64) S
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
-		if config.ShardingForkTime != nil {
+		if config.CancunTime != nil {
 			return NewDankSigner(config.ChainID)
 		}
 		if config.LondonBlock != nil {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -147,7 +147,7 @@ func init() {
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
-	case rules.IsSharding:
+	case rules.IsCancun:
 		return PrecompiledAddressesDanksharding
 	case rules.IsBerlin:
 		return PrecompiledAddressesBerlin

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -235,7 +235,7 @@ func opPush0(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	return nil, nil
 }
 
-// enable3198 applies mini-danksharding (DATAHASH Opcode)
+// enableSharding applies mini-danksharding (DATAHASH Opcode)
 // - Adds an opcode that returns the versioned data hash of the tx at a index.
 func enableSharding(jt *JumpTable) {
 	jt[DATAHASH] = &operation{

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -43,7 +43,7 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsSharding:
+	case evm.chainRules.IsCancun:
 		precompiles = PrecompiledContractsDanksharding
 	case evm.chainRules.IsBerlin:
 		precompiles = PrecompiledContractsBerlin

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -57,7 +57,7 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	var table *JumpTable
 	switch {
-	case evm.chainRules.IsSharding:
+	case evm.chainRules.IsCancun:
 		table = &shardingInstructionSet
 	case evm.chainRules.IsShanghai:
 		table = &shanghaiInstructionSet

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -462,12 +462,12 @@ func (api *ConsensusAPI) NewPayloadV2(params engine.ExecutableData) (engine.Payl
 
 // NewPayloadV3 creates an Eth1 block, inserts it in the chain, and returns the status of the chain.
 func (api *ConsensusAPI) NewPayloadV3(params engine.ExecutableData) (engine.PayloadStatusV1, error) {
-	if api.eth.BlockChain().Config().IsSharding(params.Timestamp) {
+	if api.eth.BlockChain().Config().IsCancun(params.Timestamp) {
 		if params.ExcessDataGas == nil {
-			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(fmt.Errorf("nil excessDataGas post-sharding"))
+			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(fmt.Errorf("nil excessDataGas post-cancun"))
 		}
 	} else if params.ExcessDataGas != nil {
-		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(fmt.Errorf("non-nil excessDataGas pre-sharding"))
+		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(fmt.Errorf("non-nil excessDataGas pre-cancun"))
 	}
 
 	return api.newPayload(params)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1480,7 +1480,7 @@ func TestEIP4844(t *testing.T) {
 	lastBlockTime := blocks[len(blocks)-1].Time()
 	nextBlockTime := lastBlockTime + 10 // chainmakers block time is fixed at 10 seconds
 	genesis.Config.ShanghaiTime = &nextBlockTime
-	genesis.Config.ShardingForkTime = &nextBlockTime
+	genesis.Config.CancunTime = &nextBlockTime
 	genesis.Config.TerminalTotalDifficulty.Sub(genesis.Config.TerminalTotalDifficulty, blocks[0].Difficulty())
 
 	n, ethservice := startEthService(t, genesis, blocks)
@@ -1540,7 +1540,7 @@ func TestEIP4844WithBlobTransactions(t *testing.T) {
 	lastBlockTime := blocks[len(blocks)-1].Time()
 	nextBlockTime := lastBlockTime + 10 // chainmakers block time is fixed at 10 seconds
 	genesis.Config.ShanghaiTime = &nextBlockTime
-	genesis.Config.ShardingForkTime = &nextBlockTime
+	genesis.Config.CancunTime = &nextBlockTime
 	genesis.Config.TerminalTotalDifficulty.Sub(genesis.Config.TerminalTotalDifficulty, blocks[0].Difficulty())
 
 	n, ethservice := startEthService(t, genesis, blocks)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -822,7 +822,7 @@ func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase co
 	env.tcount = 0
 
 	// Initialize the prestate excess_data_gas field used during state transition
-	if w.chainConfig.IsSharding(header.Time) {
+	if w.chainConfig.IsCancun(header.Time) {
 		// TODO(EIP-4844): Unit test this
 		env.excessDataGas = new(big.Int)
 		if parent.ExcessDataGas != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -245,7 +245,6 @@ var (
 		GrayGlacierBlock:              big.NewInt(0),
 		MergeNetsplitBlock:            nil,
 		ShanghaiTime:                  nil,
-		ShardingForkTime:              nil,
 		CancunTime:                    nil,
 		PragueTime:                    nil,
 		TerminalTotalDifficulty:       nil,
@@ -276,7 +275,6 @@ var (
 		GrayGlacierBlock:              nil,
 		MergeNetsplitBlock:            nil,
 		ShanghaiTime:                  nil,
-		ShardingForkTime:              nil,
 		CancunTime:                    nil,
 		PragueTime:                    nil,
 		TerminalTotalDifficulty:       nil,
@@ -307,7 +305,6 @@ var (
 		GrayGlacierBlock:              big.NewInt(0),
 		MergeNetsplitBlock:            nil,
 		ShanghaiTime:                  nil,
-		ShardingForkTime:              nil,
 		CancunTime:                    nil,
 		PragueTime:                    nil,
 		TerminalTotalDifficulty:       nil,
@@ -338,7 +335,6 @@ var (
 		GrayGlacierBlock:              nil,
 		MergeNetsplitBlock:            nil,
 		ShanghaiTime:                  nil,
-		ShardingForkTime:              nil,
 		CancunTime:                    nil,
 		PragueTime:                    nil,
 		TerminalTotalDifficulty:       nil,
@@ -438,10 +434,9 @@ type ChainConfig struct {
 
 	// Fork scheduling was switched from blocks to timestamps here
 
-	ShanghaiTime     *uint64 `json:"shanghaiTime,omitempty"`     // Shanghai switch time (nil = no fork, 0 = already on shanghai)
-	ShardingForkTime *uint64 `json:"shardingForkTime,omitempty"` // Mini-Danksharding switch block (nil = no fork, 0 = already activated)
-	CancunTime       *uint64 `json:"cancunTime,omitempty"`       // Cancun switch time (nil = no fork, 0 = already on cancun)
-	PragueTime       *uint64 `json:"pragueTime,omitempty"`       // Prague switch time (nil = no fork, 0 = already on prague)
+	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty"` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
+	CancunTime   *uint64 `json:"cancunTime,omitempty"`   // Cancun switch time (nil = no fork, 0 = already on cancun)
+	PragueTime   *uint64 `json:"pragueTime,omitempty"`   // Prague switch time (nil = no fork, 0 = already on prague)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -556,9 +551,6 @@ func (c *ChainConfig) Description() string {
 	if c.ShanghaiTime != nil {
 		banner += fmt.Sprintf(" - Shanghai:                    @%-10v (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md)\n", *c.ShanghaiTime)
 	}
-	if c.ShardingForkTime != nil {
-		banner += fmt.Sprintf(" - ShardingFork:                @%-10v\n", *c.ShardingForkTime)
-	}
 	if c.CancunTime != nil {
 		banner += fmt.Sprintf(" - Cancun:                      @%-10v\n", *c.CancunTime)
 	}
@@ -653,11 +645,6 @@ func (c *ChainConfig) IsShanghai(time uint64) bool {
 	return isTimestampForked(c.ShanghaiTime, time)
 }
 
-// IsSharding returns whether time is either equal to the Mini-Danksharding fork time or greater.
-func (c *ChainConfig) IsSharding(time uint64) bool {
-	return isTimestampForked(c.ShardingForkTime, time)
-}
-
 // IsCancun returns whether num is either equal to the Cancun fork time or greater.
 func (c *ChainConfig) IsCancun(time uint64) bool {
 	return isTimestampForked(c.CancunTime, time)
@@ -720,7 +707,6 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "grayGlacierBlock", block: c.GrayGlacierBlock, optional: true},
 		{name: "mergeNetsplitBlock", block: c.MergeNetsplitBlock, optional: true},
 		{name: "shanghaiTime", timestamp: c.ShanghaiTime},
-		{name: "shardingForkTime", timestamp: c.ShardingForkTime},
 		{name: "cancunTime", timestamp: c.CancunTime, optional: true},
 		{name: "pragueTime", timestamp: c.PragueTime, optional: true},
 	} {
@@ -819,9 +805,6 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkTimestampIncompatible(c.ShanghaiTime, newcfg.ShanghaiTime, headTimestamp) {
 		return newTimestampCompatError("Shanghai fork timestamp", c.ShanghaiTime, newcfg.ShanghaiTime)
-	}
-	if isForkTimestampIncompatible(c.ShardingForkTime, newcfg.ShardingForkTime, headTimestamp) {
-		return newTimestampCompatError("Sharding fork timestamp", c.ShardingForkTime, newcfg.ShardingForkTime)
 	}
 	if isForkTimestampIncompatible(c.CancunTime, newcfg.CancunTime, headTimestamp) {
 		return newTimestampCompatError("Cancun fork timestamp", c.CancunTime, newcfg.CancunTime)
@@ -973,7 +956,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
-	IsMerge, IsShanghai, IsSharding, isCancun, isPrague     bool
+	IsMerge, IsShanghai, IsCancun, isPrague                 bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -996,8 +979,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
 		IsShanghai:       c.IsShanghai(timestamp),
-		IsSharding:       c.IsSharding(timestamp),
-		isCancun:         c.IsCancun(timestamp),
+		IsCancun:         c.IsCancun(timestamp),
 		isPrague:         c.IsPrague(timestamp),
 	}
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -299,7 +299,7 @@ var Forks = map[string]*params.ChainConfig{
 		TerminalTotalDifficulty: big.NewInt(0),
 		ShanghaiTime:            u64(15_000),
 	},
-	"ShardingFork": {
+	"Cancun": {
 		ChainID:                 big.NewInt(1),
 		HomesteadBlock:          big.NewInt(0),
 		EIP150Block:             big.NewInt(0),
@@ -316,9 +316,9 @@ var Forks = map[string]*params.ChainConfig{
 		MergeNetsplitBlock:      big.NewInt(0),
 		TerminalTotalDifficulty: big.NewInt(0),
 		ShanghaiTime:            u64(0),
-		ShardingForkTime:        u64(0),
+		CancunTime:              u64(0),
 	},
-	"ShanghaiToShardingAtTime15k": {
+	"ShanghaiToCancunAtTime15k": {
 		ChainID:                 big.NewInt(1),
 		HomesteadBlock:          big.NewInt(0),
 		EIP150Block:             big.NewInt(0),
@@ -335,7 +335,7 @@ var Forks = map[string]*params.ChainConfig{
 		MergeNetsplitBlock:      big.NewInt(0),
 		TerminalTotalDifficulty: big.NewInt(0),
 		ShanghaiTime:            u64(0),
-		ShardingForkTime:        u64(15_000),
+		CancunTime:              u64(15_000),
 	},
 }
 

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -37,7 +37,7 @@ type TransactionTest struct {
 	EIP158         ttFork
 	Frontier       ttFork
 	Homestead      ttFork
-	Sharding       ttFork
+	Cancun         ttFork
 }
 
 type ttFork struct {
@@ -46,7 +46,7 @@ type ttFork struct {
 }
 
 func (tt *TransactionTest) Run(config *params.ChainConfig) error {
-	validateTx := func(rlpData hexutil.Bytes, signer types.Signer, isHomestead bool, isIstanbul bool, isSharding bool) (*common.Address, *common.Hash, error) {
+	validateTx := func(rlpData hexutil.Bytes, signer types.Signer, isHomestead bool, isIstanbul bool, isCancun bool) (*common.Address, *common.Hash, error) {
 		tx := new(types.Transaction)
 		if err := rlp.DecodeBytes(rlpData, tx); err != nil {
 			return nil, nil, err
@@ -73,7 +73,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 		fork        ttFork
 		isHomestead bool
 		isIstanbul  bool
-		isSharding  bool
+		isCancun    bool
 	}{
 		{"Frontier", types.FrontierSigner{}, tt.Frontier, false, false, false},
 		{"Homestead", types.HomesteadSigner{}, tt.Homestead, true, false, false},
@@ -82,9 +82,9 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 		{"Byzantium", types.NewEIP155Signer(config.ChainID), tt.Byzantium, true, false, false},
 		{"Constantinople", types.NewEIP155Signer(config.ChainID), tt.Constantinople, true, false, false},
 		{"Istanbul", types.NewEIP155Signer(config.ChainID), tt.Istanbul, true, true, false},
-		{"Sharding", types.NewEIP155Signer(config.ChainID), tt.Sharding, true, true, false},
+		{"Cancun", types.NewEIP155Signer(config.ChainID), tt.Cancun, true, true, false},
 	} {
-		sender, txhash, err := validateTx(tt.RLP, testcase.signer, testcase.isHomestead, testcase.isIstanbul, testcase.isSharding)
+		sender, txhash, err := validateTx(tt.RLP, testcase.signer, testcase.isHomestead, testcase.isIstanbul, testcase.isCancun)
 
 		if testcase.fork.Sender == (common.UnprefixedAddress{}) {
 			if err == nil {


### PR DESCRIPTION
Removed `isShardingForkTime` from the genesis configs. EIP-4844 is now enabled when `cancunTime` occurs.