### PR TITLE
cmd/evm/internal/t8ntool: Blob commitment version kzg check in t8ntool

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -179,6 +180,11 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		msg, err := core.TransactionToMessage(tx, signer, pre.Env.BaseFee)
 		if tx.Type() == types.BlobTxType && len(tx.DataHashes()) == 0 {
 			err = fmt.Errorf("blob transaction with zero blobs")
+		}
+		for _, h := range tx.DataHashes() {
+			if h[0] != kzg.BlobCommitmentVersionKZG {
+				err = fmt.Errorf("unversioned blob hash: %v", h)
+			}
 		}
 		if err != nil {
 			log.Warn("rejected tx", "index", i, "hash", tx.Hash(), "error", err)


### PR DESCRIPTION
Adds a check which enables the filling of (now) erroneous type 3 txs in `execution-spec-tests`. 

For the case/s where the `blob_versioned_hashes` don't contain the `BLOB_COMMITMENT_VERSION_KZG`.

In accordance with the following spec update: https://github.com/ethereum/EIPs/pull/7014

To (now) correctly fill these new test cases: https://github.com/ethereum/execution-spec-tests/pull/126